### PR TITLE
fix(frontend): hide buttons for reader users

### DIFF
--- a/frontend/src/views/CustomersView.vue
+++ b/frontend/src/views/CustomersView.vue
@@ -9,6 +9,7 @@ import CustomersTable from '@/components/customers/CustomersTable.vue'
 import { ref } from 'vue'
 import { faCirclePlus } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
+import { canManageCustomers } from '@/lib/permissions'
 
 const isShownCreateCustomerDrawer = ref(false)
 </script>
@@ -22,6 +23,7 @@ const isShownCreateCustomerDrawer = ref(false)
       </div>
       <!-- create customer -->
       <NeButton
+        v-if="canManageCustomers()"
         kind="secondary"
         size="lg"
         class="shrink-0"

--- a/frontend/src/views/DistributorsView.vue
+++ b/frontend/src/views/DistributorsView.vue
@@ -9,6 +9,7 @@ import DistributorsTable from '@/components/distributors/DistributorsTable.vue'
 import { ref } from 'vue'
 import { faCirclePlus } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
+import { canManageDistributors } from '@/lib/permissions'
 
 const isShownCreateDistributorDrawer = ref(false)
 </script>
@@ -22,6 +23,7 @@ const isShownCreateDistributorDrawer = ref(false)
       </div>
       <!-- create distributor -->
       <NeButton
+        v-if="canManageDistributors()"
         kind="secondary"
         size="lg"
         class="shrink-0"

--- a/frontend/src/views/ResellersView.vue
+++ b/frontend/src/views/ResellersView.vue
@@ -9,6 +9,7 @@ import ResellersTable from '@/components/resellers/ResellersTable.vue'
 import { ref } from 'vue'
 import { faCirclePlus } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
+import { canManageResellers } from '@/lib/permissions'
 
 const isShownCreateResellerDrawer = ref(false)
 </script>
@@ -22,6 +23,7 @@ const isShownCreateResellerDrawer = ref(false)
       </div>
       <!-- create reseller -->
       <NeButton
+        v-if="canManageResellers()"
         kind="secondary"
         size="lg"
         class="shrink-0"

--- a/frontend/src/views/UsersView.vue
+++ b/frontend/src/views/UsersView.vue
@@ -10,6 +10,7 @@ import { ref } from 'vue'
 import { faCirclePlus } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import { PRODUCT_NAME } from '@/lib/config'
+import { canManageUsers } from '@/lib/permissions'
 
 const isShownCreateUserDrawer = ref(false)
 </script>
@@ -22,7 +23,13 @@ const isShownCreateUserDrawer = ref(false)
         {{ $t('users.page_description', { productName: PRODUCT_NAME }) }}
       </div>
       <!-- create user -->
-      <NeButton kind="secondary" size="lg" class="shrink-0" @click="isShownCreateUserDrawer = true">
+      <NeButton
+        v-if="canManageUsers()"
+        kind="secondary"
+        size="lg"
+        class="shrink-0"
+        @click="isShownCreateUserDrawer = true"
+      >
         <template #prefix>
           <FontAwesomeIcon :icon="faCirclePlus" aria-hidden="true" />
         </template>


### PR DESCRIPTION
## 📋 Description

For reader users, hide the buttons to create organizations and users.

**Related Issue:** #[ISSUE_NUMBER]

## 🚀 Testing Environment

To trigger a fresh deployment of all services in the PR preview environment, comment:
```
update deploy
```

**Automatic PR environments:**
- Backend: https://my-backend-qa-pr-16.onrender.com
- Collect: https://my-collect-qa-pr-16.onrender.com
- Frontend: https://my-frontend-qa-pr-16.onrender.com
- Proxy: https://my-proxy-qa-pr-16.onrender.com

## ✅ Merge Checklist

**Code Quality:**
- [![Backend Tests](https://img.shields.io/badge/Backend%20Tests-passing-brightgreen)](https://github.com/NethServer/my/actions/runs/16676063565/job/47202848490)
- [![Collect Tests](https://img.shields.io/badge/Collect%20Tests-passing-brightgreen)](https://github.com/NethServer/my/actions/runs/16676063565/job/47202848514)
- [![Sync Tests](https://img.shields.io/badge/Sync%20Tests-passing-brightgreen)](https://github.com/NethServer/my/actions/runs/16676063565/job/47202848452)
- [![Frontend Tests](https://img.shields.io/badge/Frontend%20Tests-passing-brightgreen)](https://github.com/NethServer/my/actions/runs/16676063565/job/47202848564)

**Builds:**
- [![Backend Build](https://img.shields.io/badge/Backend%20Build-passing-brightgreen)](https://github.com/NethServer/my/actions/runs/16676063565/job/47202880753)
- [![Collect Build](https://img.shields.io/badge/Collect%20Build-passing-brightgreen)](https://github.com/NethServer/my/actions/runs/16676063565/job/47202877734)
- [![Sync Build](https://img.shields.io/badge/Sync%20Build-passing-brightgreen)](https://github.com/NethServer/my/actions/runs/16676063565/job/47202876111)
- [![Frontend Build](https://img.shields.io/badge/Frontend%20Build-passing-brightgreen)](https://github.com/NethServer/my/actions/runs/16676063565/job/47202907236)
