### PR TITLE
fix: make user and organization creation atomic

### DIFF
--- a/backend/cache/roles.go
+++ b/backend/cache/roles.go
@@ -167,6 +167,19 @@ func (r *RoleNames) GetAllNames() []string {
 	return names
 }
 
+// HasRole reports whether a role with the given ID exists in the loaded role set.
+func (r *RoleNames) HasRole(roleID string) bool {
+	r.mutex.RLock()
+	defer r.mutex.RUnlock()
+
+	if !r.loaded {
+		return false
+	}
+
+	_, exists := r.roles[roleID]
+	return exists
+}
+
 // GetAccessControl returns the access control information for a role
 func (r *RoleNames) GetAccessControl(roleID string) (RoleAccessControl, bool) {
 	r.mutex.RLock()

--- a/backend/entities/local_customers.go
+++ b/backend/entities/local_customers.go
@@ -35,6 +35,17 @@ func NewLocalCustomerRepository() *LocalCustomerRepository {
 
 // Create creates a new customer in local database
 func (r *LocalCustomerRepository) Create(req *models.CreateLocalCustomerRequest) (*models.LocalCustomer, error) {
+	return r.create(r.db, req)
+}
+
+// CreateWithTx creates a new customer inside the provided transaction so the row
+// participates in the caller's atomic create-and-sync flow; a later failure rolls
+// the insert back instead of leaving an orphaned org (logto_id IS NULL).
+func (r *LocalCustomerRepository) CreateWithTx(tx *sql.Tx, req *models.CreateLocalCustomerRequest) (*models.LocalCustomer, error) {
+	return r.create(tx, req)
+}
+
+func (r *LocalCustomerRepository) create(exec dbExecer, req *models.CreateLocalCustomerRequest) (*models.LocalCustomer, error) {
 	id := uuid.New().String()
 	now := time.Now()
 
@@ -48,7 +59,7 @@ func (r *LocalCustomerRepository) Create(req *models.CreateLocalCustomerRequest)
 		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
 	`
 
-	_, err = r.db.Exec(query, id, nil, req.Name, req.Description, customDataJSON, now, now, nil)
+	_, err = exec.Exec(query, id, nil, req.Name, req.Description, customDataJSON, now, now, nil)
 	if err != nil {
 		// Check for global VAT constraint violation (from trigger function)
 		if strings.Contains(err.Error(), "VAT") && strings.Contains(err.Error(), "already exists") {

--- a/backend/entities/local_distributors.go
+++ b/backend/entities/local_distributors.go
@@ -35,6 +35,17 @@ func NewLocalDistributorRepository() *LocalDistributorRepository {
 
 // Create creates a new distributor in local database
 func (r *LocalDistributorRepository) Create(req *models.CreateLocalDistributorRequest) (*models.LocalDistributor, error) {
+	return r.create(r.db, req)
+}
+
+// CreateWithTx creates a new distributor inside the provided transaction so the row
+// participates in the caller's atomic create-and-sync flow; a later failure rolls
+// the insert back instead of leaving an orphaned org (logto_id IS NULL).
+func (r *LocalDistributorRepository) CreateWithTx(tx *sql.Tx, req *models.CreateLocalDistributorRequest) (*models.LocalDistributor, error) {
+	return r.create(tx, req)
+}
+
+func (r *LocalDistributorRepository) create(exec dbExecer, req *models.CreateLocalDistributorRequest) (*models.LocalDistributor, error) {
 	id := uuid.New().String()
 	now := time.Now()
 
@@ -48,7 +59,7 @@ func (r *LocalDistributorRepository) Create(req *models.CreateLocalDistributorRe
 		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
 	`
 
-	_, err = r.db.Exec(query, id, nil, req.Name, req.Description, customDataJSON, now, now, nil)
+	_, err = exec.Exec(query, id, nil, req.Name, req.Description, customDataJSON, now, now, nil)
 	if err != nil {
 		// Check for VAT constraint violation (from trigger function)
 		if strings.Contains(err.Error(), "VAT") && strings.Contains(err.Error(), "already exists") {

--- a/backend/entities/local_resellers.go
+++ b/backend/entities/local_resellers.go
@@ -35,6 +35,17 @@ func NewLocalResellerRepository() *LocalResellerRepository {
 
 // Create creates a new reseller in local database
 func (r *LocalResellerRepository) Create(req *models.CreateLocalResellerRequest) (*models.LocalReseller, error) {
+	return r.create(r.db, req)
+}
+
+// CreateWithTx creates a new reseller inside the provided transaction so the row
+// participates in the caller's atomic create-and-sync flow; a later failure rolls
+// the insert back instead of leaving an orphaned org (logto_id IS NULL).
+func (r *LocalResellerRepository) CreateWithTx(tx *sql.Tx, req *models.CreateLocalResellerRequest) (*models.LocalReseller, error) {
+	return r.create(tx, req)
+}
+
+func (r *LocalResellerRepository) create(exec dbExecer, req *models.CreateLocalResellerRequest) (*models.LocalReseller, error) {
 	id := uuid.New().String()
 	now := time.Now()
 
@@ -48,7 +59,7 @@ func (r *LocalResellerRepository) Create(req *models.CreateLocalResellerRequest)
 		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
 	`
 
-	_, err = r.db.Exec(query, id, nil, req.Name, req.Description, customDataJSON, now, now, nil)
+	_, err = exec.Exec(query, id, nil, req.Name, req.Description, customDataJSON, now, now, nil)
 	if err != nil {
 		// Check for VAT constraint violation (from trigger function)
 		if strings.Contains(err.Error(), "VAT") && strings.Contains(err.Error(), "already exists") {

--- a/backend/entities/local_users.go
+++ b/backend/entities/local_users.go
@@ -35,8 +35,25 @@ func NewLocalUserRepository() *LocalUserRepository {
 	}
 }
 
+// dbExecer is satisfied by *sql.DB and *sql.Tx so an insert can run either
+// standalone or inside a caller's transaction.
+type dbExecer interface {
+	Exec(query string, args ...any) (sql.Result, error)
+}
+
 // Create creates a new user in local database
 func (r *LocalUserRepository) Create(req *models.CreateLocalUserRequest) (*models.LocalUser, error) {
+	return r.create(r.db, req)
+}
+
+// CreateWithTx creates a new user inside the provided transaction so the row
+// participates in the caller's atomic create-and-sync flow; a later failure
+// rolls the insert back instead of leaving an orphaned user (logto_id IS NULL).
+func (r *LocalUserRepository) CreateWithTx(tx *sql.Tx, req *models.CreateLocalUserRequest) (*models.LocalUser, error) {
+	return r.create(tx, req)
+}
+
+func (r *LocalUserRepository) create(exec dbExecer, req *models.CreateLocalUserRequest) (*models.LocalUser, error) {
 	id := uuid.New().String()
 	now := time.Now()
 
@@ -56,7 +73,7 @@ func (r *LocalUserRepository) Create(req *models.CreateLocalUserRequest) (*model
 		return nil, fmt.Errorf("failed to marshal user_role_ids: %w", err)
 	}
 
-	_, err = r.db.Exec(query,
+	_, err = exec.Exec(query,
 		id,
 		nil, // logto_id
 		req.Username,

--- a/backend/methods/users.go
+++ b/backend/methods/users.go
@@ -81,6 +81,15 @@ func CreateUser(c *gin.Context) {
 
 		// Check each role being assigned
 		for _, roleID := range request.UserRoleIDs {
+			// Reject unknown roles up front so creation never starts with a role
+			// that does not exist (which would otherwise fail mid-sync in Logto).
+			if !roleCache.HasRole(roleID) {
+				c.JSON(http.StatusBadRequest, response.ValidationFailed("validation failed", []response.ValidationError{
+					{Key: "user_role_ids", Message: "role not found", Value: roleID},
+				}))
+				return
+			}
+
 			accessControl, exists := roleCache.GetAccessControl(roleID)
 			if exists && accessControl.HasAccessControl {
 				// This role has access control restrictions

--- a/backend/services/local/organizations.go
+++ b/backend/services/local/organizations.go
@@ -128,8 +128,8 @@ func (s *LocalOrganizationService) CreateDistributor(req *models.CreateLocalDist
 	// Update the request with the properly managed customData
 	req.CustomData = customData
 
-	// 2. Create in local DB with CustomData
-	distributor, err := s.distributorRepo.Create(req)
+	// 2. Create in local DB with CustomData inside the transaction
+	distributor, err := s.distributorRepo.CreateWithTx(tx, req)
 	if err != nil {
 		// Check for VAT constraint violation (from entities/database)
 		if strings.Contains(err.Error(), "already exists") {
@@ -178,8 +178,8 @@ func (s *LocalOrganizationService) CreateDistributor(req *models.CreateLocalDist
 			Msg("Failed to configure JIT roles for distributor organization")
 	}
 
-	// 5. Mark as synced
-	err = s.markDistributorSynced(distributor.ID, logtoOrg.ID)
+	// 5. Mark as synced (inside the transaction so logto_id commits atomically)
+	err = s.markDistributorSynced(tx, distributor.ID, logtoOrg.ID)
 	if err != nil {
 		// Log but don't fail - distributor is created in both places
 		logger.Warn().
@@ -290,8 +290,8 @@ func (s *LocalOrganizationService) CreateReseller(req *models.CreateLocalReselle
 	// Update the request with the properly managed customData
 	req.CustomData = customData
 
-	// 2. Create in local DB with CustomData
-	reseller, err := s.resellerRepo.Create(req)
+	// 2. Create in local DB with CustomData inside the transaction
+	reseller, err := s.resellerRepo.CreateWithTx(tx, req)
 	if err != nil {
 		// Check for VAT constraint violation (from entities/database)
 		if strings.Contains(err.Error(), "already exists") {
@@ -340,8 +340,8 @@ func (s *LocalOrganizationService) CreateReseller(req *models.CreateLocalReselle
 			Msg("Failed to configure JIT roles for reseller organization")
 	}
 
-	// 4. Mark as synced
-	err = s.markResellerSynced(reseller.ID, logtoOrg.ID)
+	// 4. Mark as synced (inside the transaction so logto_id commits atomically)
+	err = s.markResellerSynced(tx, reseller.ID, logtoOrg.ID)
 	if err != nil {
 		logger.Warn().
 			Err(err).
@@ -452,8 +452,8 @@ func (s *LocalOrganizationService) CreateCustomer(req *models.CreateLocalCustome
 	// Update the request with the properly managed customData
 	req.CustomData = customData
 
-	// 2. Create in local DB with CustomData
-	customer, err := s.customerRepo.Create(req)
+	// 2. Create in local DB with CustomData inside the transaction
+	customer, err := s.customerRepo.CreateWithTx(tx, req)
 	if err != nil {
 		// Check for VAT constraint violation (from entities/database)
 		if strings.Contains(err.Error(), "already exists") {
@@ -502,8 +502,8 @@ func (s *LocalOrganizationService) CreateCustomer(req *models.CreateLocalCustome
 			Msg("Failed to configure JIT roles for customer organization")
 	}
 
-	// 4. Mark as synced
-	err = s.markCustomerSynced(customer.ID, logtoOrg.ID)
+	// 4. Mark as synced (inside the transaction so logto_id commits atomically)
+	err = s.markCustomerSynced(tx, customer.ID, logtoOrg.ID)
 	if err != nil {
 		logger.Warn().
 			Err(err).
@@ -529,22 +529,23 @@ func (s *LocalOrganizationService) CreateCustomer(req *models.CreateLocalCustome
 	return customer, nil
 }
 
-// Helper methods to mark entities as synced
-func (s *LocalOrganizationService) markDistributorSynced(id, logtoID string) error {
+// Helper methods to mark entities as synced. The executor lets the create flow run
+// the UPDATE inside its transaction so logto_id commits atomically with the row.
+func (s *LocalOrganizationService) markDistributorSynced(exec sqlExecer, id, logtoID string) error {
 	query := `UPDATE distributors SET logto_id = $1, logto_synced_at = $2, logto_sync_error = NULL WHERE id = $3`
-	_, err := database.DB.Exec(query, logtoID, time.Now(), id)
+	_, err := exec.Exec(query, logtoID, time.Now(), id)
 	return err
 }
 
-func (s *LocalOrganizationService) markResellerSynced(id, logtoID string) error {
+func (s *LocalOrganizationService) markResellerSynced(exec sqlExecer, id, logtoID string) error {
 	query := `UPDATE resellers SET logto_id = $1, logto_synced_at = $2, logto_sync_error = NULL WHERE id = $3`
-	_, err := database.DB.Exec(query, logtoID, time.Now(), id)
+	_, err := exec.Exec(query, logtoID, time.Now(), id)
 	return err
 }
 
-func (s *LocalOrganizationService) markCustomerSynced(id, logtoID string) error {
+func (s *LocalOrganizationService) markCustomerSynced(exec sqlExecer, id, logtoID string) error {
 	query := `UPDATE customers SET logto_id = $1, logto_synced_at = $2, logto_sync_error = NULL WHERE id = $3`
-	_, err := database.DB.Exec(query, logtoID, time.Now(), id)
+	_, err := exec.Exec(query, logtoID, time.Now(), id)
 	return err
 }
 
@@ -807,7 +808,7 @@ func (s *LocalOrganizationService) UpdateDistributor(id string, req *models.Upda
 	}
 
 	// 6. Mark as synced
-	err = s.markDistributorSynced(id, *distributor.LogtoID)
+	err = s.markDistributorSynced(database.DB, id, *distributor.LogtoID)
 	if err != nil {
 		logger.Warn().
 			Err(err).
@@ -1018,7 +1019,7 @@ func (s *LocalOrganizationService) UpdateReseller(id string, req *models.UpdateL
 	}
 
 	// 6. Mark as synced
-	err = s.markResellerSynced(id, *reseller.LogtoID)
+	err = s.markResellerSynced(database.DB, id, *reseller.LogtoID)
 	if err != nil {
 		logger.Warn().
 			Err(err).
@@ -1229,7 +1230,7 @@ func (s *LocalOrganizationService) UpdateCustomer(id string, req *models.UpdateL
 	}
 
 	// 6. Mark as synced
-	err = s.markCustomerSynced(id, *customer.LogtoID)
+	err = s.markCustomerSynced(database.DB, id, *customer.LogtoID)
 	if err != nil {
 		logger.Warn().
 			Err(err).

--- a/backend/services/local/users.go
+++ b/backend/services/local/users.go
@@ -10,6 +10,7 @@
 package local
 
 import (
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"regexp"
@@ -179,8 +180,8 @@ func (s *LocalUserService) CreateUser(req *models.CreateLocalUserRequest, create
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	// 3. Create in local DB (after Logto validation passes)
-	user, err := s.userRepo.Create(req)
+	// 3. Create in local DB inside the transaction (after Logto validation passes)
+	user, err := s.userRepo.CreateWithTx(tx, req)
 	if err != nil {
 		// Cleanup the Logto user since local creation failed
 		if deleteErr := s.logtoClient.DeleteUser(logtoUser.ID); deleteErr != nil {
@@ -312,13 +313,19 @@ func (s *LocalUserService) CreateUser(req *models.CreateLocalUserRequest, create
 		}
 	}
 
-	// 7. Mark as synced
-	err = s.markUserSynced(user.ID, logtoUser.ID)
+	// 7. Mark as synced (inside the transaction so logto_id commits atomically)
+	err = s.markUserSynced(tx, user.ID, logtoUser.ID)
 	if err != nil {
 		logger.Warn().
 			Err(err).
 			Str("user_id", user.ID).
 			Msg("Failed to mark user as synced")
+	} else {
+		// Reflect the sync on the in-memory object so the create response carries
+		// logto_id immediately, instead of forcing the client to issue a follow-up GET.
+		syncedAt := time.Now()
+		user.LogtoID = &logtoUser.ID
+		user.LogtoSyncedAt = &syncedAt
 	}
 
 	// 8. Commit transaction
@@ -898,7 +905,7 @@ func (s *LocalUserService) UpdateUser(id string, req *models.UpdateLocalUserRequ
 	}
 
 	// 7. Mark as synced
-	err = s.markUserSynced(id, *user.LogtoID)
+	err = s.markUserSynced(database.DB, id, *user.LogtoID)
 	if err != nil {
 		logger.Warn().
 			Err(err).
@@ -1435,10 +1442,18 @@ func (s *LocalUserService) ReactivateUser(id, reactivatedByUserID, reactivatedBy
 // PRIVATE METHODS
 // =============================================================================
 
-// markUserSynced marks a user as synced with Logto
-func (s *LocalUserService) markUserSynced(id, logtoID string) error {
+// sqlExecer is satisfied by *sql.DB and *sql.Tx so a write can run either
+// standalone or inside a caller's transaction.
+type sqlExecer interface {
+	Exec(query string, args ...any) (sql.Result, error)
+}
+
+// markUserSynced marks a user as synced with Logto. The executor lets the create
+// flow run this UPDATE inside its transaction so the logto_id is committed
+// atomically with the user row.
+func (s *LocalUserService) markUserSynced(exec sqlExecer, id, logtoID string) error {
 	query := `UPDATE users SET logto_id = $1, logto_synced_at = $2 WHERE id = $3`
-	_, err := database.DB.Exec(query, logtoID, time.Now(), id)
+	_, err := exec.Exec(query, logtoID, time.Now(), id)
 	return err
 }
 


### PR DESCRIPTION
## Problem

User and organization creation *looked* transactional (open `tx`, `defer tx.Rollback()`, "rolling back local creation" logs), but the local insert (`repo.Create`) and the `logto_id` sync (`mark*Synced`) ran through the global DB pool instead of the open transaction. So when a Logto step failed after the local insert, the cleanup deleted the Logto side but `tx.Rollback()` rolled back an empty transaction — leaving an **orphaned local row with `logto_id` NULL**.

Since the whole users/orgs API addresses entities by `logto_id` (`WHERE logto_id = $1`), such a row became unaddressable: the UI sent `/users/null/destroy` and got a 404. The trigger in practice was creating a user with a role that does not exist (the Logto role assignment failed mid-sync).

## Fix

- **Atomic creation.** Thread the transaction through both the insert and the sync update so they commit (or roll back) together — for users and for distributors/resellers/customers. Added `CreateWithTx` to each repo and made `mark*Synced` take an executor (`*sql.Tx` on create, pool on update).
- **Fail fast with 400.** Reject unknown user role IDs up front (before any Logto/DB side effect) instead of failing mid-sync.
- **`logto_id` in the create response.** `POST /users` now returns the synced `logto_id` immediately instead of `null`, matching what a later `GET` returns (orgs already did this).

## Verification

- `make pre-commit` green (fmt + lint + test + validate-docs); `go build`/`vet`/`gofmt` clean.
- Live against local instance:
  - `POST /users` with a non-existent role → **400** `role not found`, **no orphan row** created.
  - `POST /users` with a valid role → **201** with `logto_id` populated atomically.
  - Distributor create → local row committed with non-null `logto_id` and `logto_synced_at`.

## Notes

- Existing orphaned rows (created before this fix, e.g. in QA) are prevented going forward but still need a one-off cleanup, since the UI can't address a `logto_id`-NULL row.
- The update flows keep their current behavior (sync on the pool); only the create flows are made atomic.