### PR TITLE
chore: change mimir resolve_timeout

### DIFF
--- a/backend/services/alerting/template.go
+++ b/backend/services/alerting/template.go
@@ -87,7 +87,7 @@ type templateData struct {
 }
 
 const alertmanagerTemplate = `global:
-  resolve_timeout: 1h
+  resolve_timeout: 6h
   smtp_smarthost: '{{ yamlEscape .SmtpSmarthost }}'
   smtp_from: '{{ yamlEscape .SmtpFrom }}'
   smtp_auth_username: '{{ yamlEscape .SmtpAuthUsername }}'


### PR DESCRIPTION
Wait at least 6 hours to resolve an alert
that has not been renewed.

With this change we can reduce the number of alerts sent from the clients.