### PR TITLE
fix(alerting): show local time alongside UTC

### DIFF
--- a/backend/configuration/configuration.go
+++ b/backend/configuration/configuration.go
@@ -76,6 +76,7 @@ type Configuration struct {
 	// Mimir configuration
 	MimirURL string `json:"mimir_url"`
 	// Alerting configuration
+	AlertingTimezone             string `json:"alerting_timezone"`
 	AlertingHistoryWebhookURL    string `json:"alerting_history_webhook_url"`
 	AlertingHistoryWebhookSecret string `json:"alerting_history_webhook_secret"`
 
@@ -260,6 +261,24 @@ func Init() {
 	} else {
 		Config.MimirURL = "http://localhost:9009"
 		logger.LogConfigLoad("env", "MIMIR_URL", true, fmt.Errorf("MIMIR_URL variable is empty, using default http://localhost:9009"))
+	}
+
+	// Timezone alert notification timestamps are rendered in (IANA name).
+	// Mimir's alertmanager resolves it via time.LoadLocation when it renders a
+	// notification, and an unresolvable name aborts the template and drops the
+	// notification — so validate the name here to catch a typo at boot instead
+	// of at delivery. This cannot prove Mimir itself can resolve it: the check
+	// runs against the backend image, not the Mimir one.
+	if tz := os.Getenv("ALERTING_TIMEZONE"); tz != "" {
+		Config.AlertingTimezone = tz
+	} else {
+		Config.AlertingTimezone = "Europe/Rome"
+	}
+	if _, err := time.LoadLocation(Config.AlertingTimezone); err != nil {
+		logger.Fatal().
+			Str("timezone", Config.AlertingTimezone).
+			Err(err).
+			Msg("ALERTING_TIMEZONE is not a valid IANA timezone; alert notifications would fail to render")
 	}
 
 	// Alerting configuration — optional, empty means no built-in history webhook.

--- a/backend/main.go
+++ b/backend/main.go
@@ -17,6 +17,12 @@ import (
 	"syscall"
 	"time"
 
+	// Embed the IANA timezone database in the binary. ALERTING_TIMEZONE is
+	// validated with time.LoadLocation at startup, and the runtime image is
+	// alpine without the tzdata package, so without this every zone name
+	// fails to resolve and the backend refuses to boot.
+	_ "time/tzdata"
+
 	"github.com/gin-contrib/cors"
 	"github.com/gin-contrib/gzip"
 	"github.com/gin-gonic/gin"

--- a/backend/services/alerting/effective.go
+++ b/backend/services/alerting/effective.go
@@ -257,7 +257,7 @@ func renderTenantConfig(tenantOrgID string) (string, map[string]string, error) {
 	if err != nil {
 		return "", nil, fmt.Errorf("render YAML for %s: %w", tenantOrgID, err)
 	}
-	templateFiles, err := BuildTemplateFiles(cfg.AppURL)
+	templateFiles, err := BuildTemplateFiles(cfg.AppURL, cfg.AlertingTimezone)
 	if err != nil {
 		return "", nil, fmt.Errorf("build templates for %s: %w", tenantOrgID, err)
 	}

--- a/backend/services/alerting/embed.go
+++ b/backend/services/alerting/embed.go
@@ -30,6 +30,14 @@ var ValidTemplateLangs = []string{"en", "it"}
 // language-specific templates, used by the "view system" CTA to build a
 // link to the frontend.
 //
+// timezone is substituted into the ${ALERT_TZ} placeholder, the IANA zone
+// every notification timestamp is rendered in. It is deployment-wide rather
+// than per-recipient: the zone abbreviation is printed alongside the time so
+// the value stays unambiguous for a recipient reading it from elsewhere.
+// Mimir's alertmanager resolves it with time.LoadLocation, so the Mimir
+// image must ship tzdata (see services/mimir/Containerfile) — a name it
+// cannot resolve aborts template execution and the notification is dropped.
+//
 // Output layout:
 //
 //	firing_en.html / firing_en.txt / firing_en.subject (defined in firing_en.html)
@@ -37,7 +45,7 @@ var ValidTemplateLangs = []string{"en", "it"}
 //	telegram_en.tmpl
 //	(same for it)
 //	_dispatcher.tmpl  — defines alert_en.{html,txt,subject} and alert_it.{html,txt,subject}
-func BuildTemplateFiles(appURL string) (map[string]string, error) {
+func BuildTemplateFiles(appURL, timezone string) (map[string]string, error) {
 	files := map[string]string{}
 	for _, lang := range ValidTemplateLangs {
 		names := []string{
@@ -52,9 +60,18 @@ func BuildTemplateFiles(appURL string) (map[string]string, error) {
 			if err != nil {
 				return nil, fmt.Errorf("loading alert template %s: %w", name, err)
 			}
-			files[name] = strings.ReplaceAll(string(content), "${APP_URL}", appURL)
+			rendered := strings.ReplaceAll(string(content), "${APP_URL}", appURL)
+			files[name] = strings.ReplaceAll(rendered, "${ALERT_TZ}", timezone)
 		}
 	}
+	// Language-independent helpers (ts_it / ts_en / ts_utc), shared by every
+	// template above so the timestamp format lives in one file.
+	datetime, err := templateFS.ReadFile("templates/_datetime.tmpl")
+	if err != nil {
+		return nil, fmt.Errorf("loading alert template _datetime.tmpl: %w", err)
+	}
+	files["_datetime.tmpl"] = strings.ReplaceAll(string(datetime), "${ALERT_TZ}", timezone)
+
 	files["_dispatcher.tmpl"] = buildDispatcher()
 	return files, nil
 }

--- a/backend/services/alerting/render_test.go
+++ b/backend/services/alerting/render_test.go
@@ -1,0 +1,437 @@
+/*
+Copyright (C) 2026 Nethesis S.r.l.
+SPDX-License-Identifier: AGPL-3.0-or-later
+*/
+
+package alerting
+
+import (
+	htmltpl "html/template"
+	"regexp"
+	"strings"
+	"testing"
+	texttpl "text/template"
+	"time"
+	"unicode/utf8"
+)
+
+// The alert notification templates are executed by Mimir's alertmanager, not
+// by this codebase, so nothing here would otherwise notice a template that
+// fails to render — a broken one is only visible as a notification that never
+// arrives. These tests execute the shipped bundle against the same data shape
+// and function map alertmanager uses, so a bad expression fails the build
+// instead of silently dropping mail.
+
+// amFuncs mirrors the subset of alertmanager's DefaultFuncs the templates use.
+// Keep in sync with the vendored fork (grafana/prometheus-alertmanager): note
+// it exposes only date/tz, NOT since/now/humanizeDuration.
+func amFuncs() map[string]any {
+	return map[string]any{
+		"toUpper": strings.ToUpper,
+		"toLower": strings.ToLower,
+		"date":    func(format string, t time.Time) string { return t.Format(format) },
+		"tz": func(name string, t time.Time) (time.Time, error) {
+			loc, err := time.LoadLocation(name)
+			if err != nil {
+				return time.Time{}, err
+			}
+			return t.In(loc), nil
+		},
+	}
+}
+
+// amAlert / amData mirror alertmanager's template data. .Alerts.Firing and
+// .Alerts.Resolved are methods on the real type and plain fields here; the
+// templates reach them identically either way.
+type amAlert struct {
+	Labels      map[string]string
+	Annotations map[string]string
+	StartsAt    time.Time
+	EndsAt      time.Time
+}
+
+type amData struct {
+	Status string
+	Alerts struct {
+		Firing   []amAlert
+		Resolved []amAlert
+	}
+	CommonLabels map[string]string
+}
+
+func sampleAlert(startsAt, endsAt time.Time) amAlert {
+	return amAlert{
+		Labels: map[string]string{
+			"alertname":         "SystemDown",
+			"severity":          "critical",
+			"service":           "node",
+			"organization_name": "Rossi Informatica Srl",
+			"organization_type": "customer",
+			"organization_vat":  "01234567890",
+			"system_name":       "srv-milano-01",
+			"system_key":        "a1b2c3d4",
+			"system_fqdn":       "srv-milano-01.rossi.local",
+			"system_id":         "42",
+		},
+		Annotations: map[string]string{
+			"summary_it":     "Il sistema non risponde",
+			"summary_en":     "System is unreachable",
+			"description_it": "Nessun dato ricevuto dal sistema negli ultimi 10 minuti.",
+			"description_en": "No data received from the system in the last 10 minutes.",
+		},
+		StartsAt: startsAt,
+		EndsAt:   endsAt,
+	}
+}
+
+func sampleData(status string, a amAlert) amData {
+	d := amData{Status: status, CommonLabels: a.Labels}
+	if status == "firing" {
+		d.Alerts.Firing = []amAlert{a}
+	} else {
+		d.Alerts.Resolved = []amAlert{a}
+	}
+	return d
+}
+
+// renderBundle executes one named template out of the BuildTemplateFiles
+// bundle. htmlSet picks html/template over text/template, matching how
+// alertmanager renders the `html` field versus `text`/`message`/`Subject`.
+func renderBundle(t *testing.T, files map[string]string, name string, htmlSet bool, data amData) string {
+	t.Helper()
+	var (
+		out strings.Builder
+		err error
+	)
+	if htmlSet {
+		tmpl := htmltpl.New("root").Funcs(amFuncs())
+		for _, src := range files {
+			if tmpl, err = tmpl.Parse(src); err != nil {
+				t.Fatalf("parse %s: %v", name, err)
+			}
+		}
+		err = tmpl.ExecuteTemplate(&out, name, data)
+	} else {
+		tmpl := texttpl.New("root").Funcs(amFuncs())
+		for _, src := range files {
+			if tmpl, err = tmpl.Parse(src); err != nil {
+				t.Fatalf("parse %s: %v", name, err)
+			}
+		}
+		err = tmpl.ExecuteTemplate(&out, name, data)
+	}
+	if err != nil {
+		t.Fatalf("execute %s: %v", name, err)
+	}
+	return out.String()
+}
+
+// TestTemplates_RenderWithoutError executes every entry point alertmanager
+// references — the per-language dispatchers for both statuses, plus the
+// Telegram message — and checks nothing is left unsubstituted.
+func TestTemplates_RenderWithoutError(t *testing.T) {
+	files, err := BuildTemplateFiles("https://my.nethesis.it", "Europe/Rome")
+	if err != nil {
+		t.Fatalf("BuildTemplateFiles: %v", err)
+	}
+	alert := sampleAlert(
+		time.Date(2026, 7, 3, 11, 40, 13, 0, time.UTC),
+		time.Date(2026, 7, 3, 12, 12, 41, 0, time.UTC),
+	)
+
+	for _, lang := range ValidTemplateLangs {
+		for _, status := range []string{"firing", "resolved"} {
+			data := sampleData(status, alert)
+			for _, tc := range []struct {
+				name    string
+				htmlSet bool
+			}{
+				{"alert_" + lang + ".html", true},
+				{"alert_" + lang + ".txt", false},
+				{"alert_" + lang + ".subject", false},
+				{"telegram_" + lang + ".message", false},
+			} {
+				out := renderBundle(t, files, tc.name, tc.htmlSet, data)
+				if out == "" {
+					t.Errorf("%s (%s): rendered empty", tc.name, status)
+				}
+				if strings.Contains(out, "${") {
+					t.Errorf("%s (%s): unsubstituted placeholder in output", tc.name, status)
+				}
+			}
+		}
+	}
+}
+
+// TestTemplates_TimestampsUseConfiguredTimezone pins the rendered timestamp
+// format, including the DST-dependent zone abbreviation. The offset and the
+// abbreviation both come from tzdata, so this also fails if the timezone is
+// unresolvable in the environment running the test.
+func TestTemplates_TimestampsUseConfiguredTimezone(t *testing.T) {
+	files, err := BuildTemplateFiles("https://my.nethesis.it", "Europe/Rome")
+	if err != nil {
+		t.Fatalf("BuildTemplateFiles: %v", err)
+	}
+
+	cases := []struct {
+		name     string
+		startsAt time.Time
+		lang     string
+		want     string
+	}{
+		{"it summer CEST", time.Date(2026, 7, 3, 11, 40, 13, 0, time.UTC), "it", "03 lug 2026, 13:40 CEST"},
+		{"it winter CET", time.Date(2026, 1, 15, 11, 40, 13, 0, time.UTC), "it", "15 gen 2026, 12:40 CET"},
+		{"en summer CEST", time.Date(2026, 7, 3, 11, 40, 13, 0, time.UTC), "en", "Jul 03, 2026, 01:40 PM CEST"},
+		{"en winter CET", time.Date(2026, 1, 15, 11, 40, 13, 0, time.UTC), "en", "Jan 15, 2026, 12:40 PM CET"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			data := sampleData("firing", sampleAlert(tc.startsAt, tc.startsAt.Add(30*time.Minute)))
+			for _, target := range []struct {
+				name    string
+				htmlSet bool
+			}{
+				{"alert_" + tc.lang + ".html", true},
+				{"alert_" + tc.lang + ".txt", false},
+				{"telegram_" + tc.lang + ".message", false},
+			} {
+				out := renderBundle(t, files, target.name, target.htmlSet, data)
+				if !strings.Contains(out, tc.want) {
+					t.Errorf("%s: missing %q in output", target.name, tc.want)
+				}
+				// The UTC duplicate this format replaced carried seconds.
+				if strings.Contains(out, "11:40:13") {
+					t.Errorf("%s: unexpected seconds-precision timestamp in output", target.name)
+				}
+			}
+		})
+	}
+}
+
+// TestBuildTemplateFiles_TimezoneIsSubstituted guards the placeholder itself:
+// a template that hardcodes a zone instead of using ${ALERT_TZ} would silently
+// ignore ALERTING_TIMEZONE.
+func TestBuildTemplateFiles_TimezoneIsSubstituted(t *testing.T) {
+	files, err := BuildTemplateFiles("https://my.nethesis.it", "America/New_York")
+	if err != nil {
+		t.Fatalf("BuildTemplateFiles: %v", err)
+	}
+	for name, src := range files {
+		if strings.Contains(src, "${ALERT_TZ}") {
+			t.Errorf("%s: ${ALERT_TZ} left unsubstituted", name)
+		}
+		if strings.Contains(src, `tz "Europe/`) {
+			t.Errorf("%s: hardcoded timezone instead of ${ALERT_TZ}", name)
+		}
+		// Only the shared helper may call tz; a template formatting a
+		// timestamp inline would drift from the rest.
+		if name != "_datetime.tmpl" && strings.Contains(src, "tz ") {
+			t.Errorf("%s: calls tz directly, use the ts_it/ts_en templates", name)
+		}
+	}
+
+	data := sampleData("firing", sampleAlert(
+		time.Date(2026, 7, 3, 11, 40, 13, 0, time.UTC),
+		time.Date(2026, 7, 3, 12, 12, 41, 0, time.UTC),
+	))
+	out := renderBundle(t, files, "alert_it.txt", false, data)
+	if want := "03 lug 2026, 07:40 EDT"; !strings.Contains(out, want) {
+		t.Errorf("missing %q in output rendered with America/New_York", want)
+	}
+}
+
+// TestTemplates_UTCLineNotInTelegram pins where the secondary UTC timestamp
+// appears: both email bodies carry it as a second line under the local time —
+// muted grey in the HTML, indented to the value column in the plain text. The
+// Telegram message does not: it is a chat notification where a second line per
+// timestamp costs more than the correlation with server logs is worth there.
+func TestTemplates_UTCLineNotInTelegram(t *testing.T) {
+	files, err := BuildTemplateFiles("https://my.nethesis.it", "Europe/Rome")
+	if err != nil {
+		t.Fatalf("BuildTemplateFiles: %v", err)
+	}
+	data := sampleData("firing", sampleAlert(
+		time.Date(2026, 7, 3, 11, 40, 13, 0, time.UTC),
+		time.Date(2026, 7, 3, 12, 12, 41, 0, time.UTC),
+	))
+	const utcStamp = "2026-07-03 11:40 UTC"
+
+	for _, lang := range ValidTemplateLangs {
+		if out := renderBundle(t, files, "alert_"+lang+".html", true, data); !strings.Contains(out, utcStamp) {
+			t.Errorf("alert_%s.html: missing the secondary UTC line %q", lang, utcStamp)
+		}
+		if out := renderBundle(t, files, "alert_"+lang+".txt", false, data); !strings.Contains(out, utcStamp) {
+			t.Errorf("alert_%s.txt: missing the secondary UTC line %q", lang, utcStamp)
+		}
+		if out := renderBundle(t, files, "telegram_"+lang+".message", false, data); strings.Contains(out, utcStamp) {
+			t.Errorf("telegram_%s.message: UTC line does not belong in the Telegram body", lang)
+		}
+	}
+}
+
+// TestPlainTextUTCLine_AlignedToValueColumn keeps the secondary UTC line under
+// the value it belongs to rather than under the label — the indentation is the
+// only thing marking it as secondary in a body with no styling.
+func TestPlainTextUTCLine_AlignedToValueColumn(t *testing.T) {
+	files, err := BuildTemplateFiles("https://my.nethesis.it", "Europe/Rome")
+	if err != nil {
+		t.Fatalf("BuildTemplateFiles: %v", err)
+	}
+	data := sampleData("resolved", sampleAlert(
+		time.Date(2026, 7, 3, 11, 40, 13, 0, time.UTC),
+		time.Date(2026, 7, 3, 12, 12, 41, 0, time.UTC),
+	))
+	widths := map[string]int{"it": 16, "en": 14}
+
+	for _, lang := range ValidTemplateLangs {
+		out := renderBundle(t, files, "alert_"+lang+".txt", false, data)
+		found := 0
+		for _, line := range strings.Split(out, "\n") {
+			if !strings.Contains(line, "UTC") || strings.TrimSpace(line) == "" {
+				continue
+			}
+			trimmed := strings.TrimLeft(line, " ")
+			indent := utf8.RuneCountInString(line) - utf8.RuneCountInString(trimmed)
+			if indent != widths[lang] {
+				t.Errorf("alert_%s.txt: UTC line %q indented %d, want %d", lang, trimmed, indent, widths[lang])
+			}
+			found++
+		}
+		if found != 2 {
+			t.Errorf("alert_%s.txt: found %d UTC lines in a resolved body, want 2", lang, found)
+		}
+	}
+}
+
+// TestLabels_SameWordingAcrossChannels pins the wording of every field label.
+// The three media style labels differently on purpose — the plain text uses an
+// aligned uppercase column, the HTML a styled uppercase cell with no colon, the
+// Telegram message inline sentence case — but the words themselves must match,
+// so the same alert reads the same way wherever it lands.
+func TestLabels_SameWordingAcrossChannels(t *testing.T) {
+	files, err := BuildTemplateFiles("https://my.nethesis.it", "Europe/Rome")
+	if err != nil {
+		t.Fatalf("BuildTemplateFiles: %v", err)
+	}
+
+	cases := []struct {
+		kind     string // firing | resolved
+		lang     string
+		text     string // aligned column label, colon included
+		html     string // styled label cell
+		telegram string // inline label, colon included
+	}{
+		{"firing", "it", "ATTIVO DAL:", ">ATTIVO DAL<", "Attivo dal:"},
+		{"resolved", "it", "INIZIO:", ">INIZIO<", "Inizio:"},
+		{"resolved", "it", "RISOLTO:", ">RISOLTO<", "Risolto:"},
+		{"firing", "en", "FIRING SINCE:", ">FIRING SINCE<", "Firing since:"},
+		{"resolved", "en", "STARTED:", ">STARTED<", "Started:"},
+		{"resolved", "en", "RESOLVED:", ">RESOLVED<", "Resolved:"},
+		{"firing", "it", "DETTAGLI:", ">DETTAGLI<", "Dettagli:"},
+		{"firing", "en", "DETAILS:", ">DETAILS<", "Details:"},
+		// One label per organization_type, including the fallback branch. The
+		// three narrow ones used to be abbreviated in the plain text column
+		// only, which is exactly the divergence this pins down.
+		{"firing", "it", "CLIENTE:", "}}CLIENTE{{", "}}Cliente{{"},
+		{"firing", "it", "RIVENDITORE:", "}}RIVENDITORE{{", "}}Rivenditore{{"},
+		{"firing", "it", "DISTRIBUTORE:", "}}DISTRIBUTORE{{", "}}Distributore{{"},
+		{"firing", "it", "ORGANIZZAZIONE:", "}}ORGANIZZAZIONE{{", "}}Organizzazione{{"},
+		{"firing", "en", "CUSTOMER:", "}}CUSTOMER{{", "}}Customer{{"},
+		{"firing", "en", "RESELLER:", "}}RESELLER{{", "}}Reseller{{"},
+		{"firing", "en", "DISTRIBUTOR:", "}}DISTRIBUTOR{{", "}}Distributor{{"},
+		{"firing", "en", "ORGANIZATION:", "}}ORGANIZATION{{", "}}Organization{{"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.kind+"/"+tc.lang+"/"+tc.text, func(t *testing.T) {
+			if got := files[tc.kind+"_"+tc.lang+".txt"]; !strings.Contains(got, tc.text) {
+				t.Errorf("%s_%s.txt: missing label %q", tc.kind, tc.lang, tc.text)
+			}
+			if got := files[tc.kind+"_"+tc.lang+".html"]; !strings.Contains(got, tc.html) {
+				t.Errorf("%s_%s.html: missing label %q", tc.kind, tc.lang, tc.html)
+			}
+			if got := files["telegram_"+tc.lang+".tmpl"]; !strings.Contains(got, tc.telegram) {
+				t.Errorf("telegram_%s.tmpl: missing label %q", tc.lang, tc.telegram)
+			}
+		})
+	}
+}
+
+// TestPlainTextLabels_Aligned checks the fixed-width label column in the plain
+// text bodies. Every branch has to pad to the same column, including the org
+// fallback that only fires when organization_type is unrecognised — the case
+// that is easiest to leave behind when a label is renamed.
+func TestPlainTextLabels_Aligned(t *testing.T) {
+	files, err := BuildTemplateFiles("https://my.nethesis.it", "Europe/Rome")
+	if err != nil {
+		t.Fatalf("BuildTemplateFiles: %v", err)
+	}
+	// Widths fit the longest label each language can emit: ORGANIZZAZIONE: and
+	// ORGANIZATION:, both from the fallback branch.
+	widths := map[string]int{"it": 16, "en": 14}
+	label := regexp.MustCompile(`(?m)(?:^|\}\})([A-ZÀ-Ù][A-ZÀ-Ù'. ]*?:)( +)`)
+
+	for _, name := range []string{"firing_it.txt", "resolved_it.txt", "firing_en.txt", "resolved_en.txt"} {
+		lang := "en"
+		if strings.Contains(name, "_it") {
+			lang = "it"
+		}
+		want := widths[lang]
+		for _, m := range label.FindAllStringSubmatch(files[name], -1) {
+			// Runes, not bytes: SEVERITÀ: is 9 columns wide but 10 bytes long.
+			got := utf8.RuneCountInString(m[1]) + utf8.RuneCountInString(m[2])
+			if got != want {
+				t.Errorf("%s: label %q occupies %d columns, want %d", name, m[1], got, want)
+			}
+		}
+	}
+}
+
+// TestLabels_NoRetiredWording fails if a superseded label creeps back in.
+func TestLabels_NoRetiredWording(t *testing.T) {
+	files, err := BuildTemplateFiles("https://my.nethesis.it", "Europe/Rome")
+	if err != nil {
+		t.Fatalf("BuildTemplateFiles: %v", err)
+	}
+	retired := []string{
+		"DESCRIZIONE", "DESCRIPTION", // superseded by DETTAGLI / DETAILS
+		"SEVERITA'",           // superseded by SEVERITÀ
+		"Attivo da:",          // superseded by Attivo dal: / Inizio:
+		"RIVEND.", "DISTRIB.", // abbreviations dropped for the full wording
+		"ORG.:", "ORGANIZATION:", // ORG.: dropped; ORGANIZATION: only in the txt column
+	}
+	for name, src := range files {
+		for _, word := range retired {
+			// ORGANIZATION:/ORGANIZZAZIONE: are legitimate in the plain text column.
+			if strings.HasSuffix(word, ":") && strings.HasSuffix(name, ".txt") {
+				continue
+			}
+			if strings.Contains(src, word) {
+				t.Errorf("%s: retired label %q is back", name, word)
+			}
+		}
+	}
+}
+
+// TestMonthIT_AllMonths covers the hand-written Italian month abbreviations —
+// a table Go's time package cannot provide, so nothing else would catch a typo
+// or a missing branch.
+func TestMonthIT_AllMonths(t *testing.T) {
+	files, err := BuildTemplateFiles("https://my.nethesis.it", "UTC")
+	if err != nil {
+		t.Fatalf("BuildTemplateFiles: %v", err)
+	}
+	want := []string{"gen", "feb", "mar", "apr", "mag", "giu", "lug", "ago", "set", "ott", "nov", "dic"}
+	for i, abbr := range want {
+		month := time.Month(i + 1)
+		data := sampleData("firing", sampleAlert(
+			time.Date(2026, month, 9, 8, 30, 0, 0, time.UTC),
+			time.Date(2026, month, 9, 9, 0, 0, 0, time.UTC),
+		))
+		out := renderBundle(t, files, "alert_it.txt", false, data)
+		if expect := "09 " + abbr + " 2026, 08:30 UTC"; !strings.Contains(out, expect) {
+			t.Errorf("month %d: missing %q", i+1, expect)
+		}
+	}
+}

--- a/backend/services/alerting/template.go
+++ b/backend/services/alerting/template.go
@@ -197,6 +197,7 @@ templates:
   - 'resolved_it.html'
   - 'firing_it.txt'
   - 'resolved_it.txt'
+  - '_datetime.tmpl'
   - '_dispatcher.tmpl'
   - 'telegram_en.tmpl'
   - 'telegram_it.tmpl'

--- a/backend/services/alerting/template_test.go
+++ b/backend/services/alerting/template_test.go
@@ -168,7 +168,7 @@ func TestRenderConfig_HistoryWebhook(t *testing.T) {
 }
 
 func TestBuildTemplateFiles_AllLanguagesPresent(t *testing.T) {
-	files, err := BuildTemplateFiles("https://app.example")
+	files, err := BuildTemplateFiles("https://app.example", "Europe/Rome")
 	if err != nil {
 		t.Fatalf("BuildTemplateFiles error: %v", err)
 	}
@@ -186,7 +186,7 @@ func TestBuildTemplateFiles_AllLanguagesPresent(t *testing.T) {
 }
 
 func TestBuildTemplateFiles_DispatcherDefinesPerLanguage(t *testing.T) {
-	files, err := BuildTemplateFiles("https://app.example")
+	files, err := BuildTemplateFiles("https://app.example", "Europe/Rome")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/backend/services/alerting/templates/_datetime.tmpl
+++ b/backend/services/alerting/templates/_datetime.tmpl
@@ -1,0 +1,26 @@
+{{/*
+Shared timestamp rendering for every notification template.
+
+The zone is substituted once at build time into ${ALERT_TZ}, so the format and
+the timezone each live in exactly one place instead of being repeated across
+ten template files.
+
+Formats mirror formatDateTimeNoSeconds() in frontend/src/lib/dateTime.ts, so a
+timestamp reads identically in an email and in the app:
+
+	it   03 lug 2026, 13:40 CEST
+	en   Jul 03, 2026, 01:40 PM CEST
+
+Go's time layouts only speak English, so the Italian month abbreviation is
+spelled out below. Alertmanager's function map (the grafana fork vendored by
+Mimir) offers only date/tz/toUpper/toLower/join/match/reReplaceAll/stringSlice
+— no arithmetic and no map constructor — so a month lookup table is not
+expressible and the comparison chain is the available option.
+
+ts_utc renders the same instant in UTC for the muted secondary line in the
+HTML emails; MST resolves to "UTC" for a UTC time, no literal needed.
+*/}}
+{{ define "month_it" }}{{ $m := date "01" . }}{{ if eq $m "01" }}gen{{ else if eq $m "02" }}feb{{ else if eq $m "03" }}mar{{ else if eq $m "04" }}apr{{ else if eq $m "05" }}mag{{ else if eq $m "06" }}giu{{ else if eq $m "07" }}lug{{ else if eq $m "08" }}ago{{ else if eq $m "09" }}set{{ else if eq $m "10" }}ott{{ else if eq $m "11" }}nov{{ else }}dic{{ end }}{{ end }}
+{{ define "ts_it" }}{{ $t := tz "${ALERT_TZ}" . }}{{ date "02 " $t }}{{ template "month_it" $t }}{{ date " 2006, 15:04 MST" $t }}{{ end }}
+{{ define "ts_en" }}{{ date "Jan 02, 2006, 03:04 PM MST" (tz "${ALERT_TZ}" .) }}{{ end }}
+{{ define "ts_utc" }}{{ date "2006-01-02 15:04 MST" .UTC }}{{ end }}

--- a/backend/services/alerting/templates/firing_en.html
+++ b/backend/services/alerting/templates/firing_en.html
@@ -148,7 +148,7 @@
                           <td style="padding-bottom: 18px;">
                             <table border="0" cellpadding="0" cellspacing="0" width="100%">
                               <tr>
-                                <td style="font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.8px; color: #6b7280; font-family: 'Poppins', Arial, sans-serif; padding-bottom: 6px;">DESCRIPTION</td>
+                                <td style="font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.8px; color: #6b7280; font-family: 'Poppins', Arial, sans-serif; padding-bottom: 6px;">DETAILS</td>
                               </tr>
                               <tr>
                                 <td style="font-size: 14px; color: #374151; line-height: 1.5; font-family: 'Poppins', Arial, sans-serif;">{{ if .Annotations.description_en }}{{ .Annotations.description_en }}{{ else }}{{ .Annotations.description }}{{ end }}</td>
@@ -166,7 +166,10 @@
                                 <td style="font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.8px; color: #6b7280; font-family: 'Poppins', Arial, sans-serif; padding-bottom: 6px;">FIRING SINCE</td>
                               </tr>
                               <tr>
-                                <td style="font-size: 13px; color: #dc2626; font-family: 'Poppins', Arial, sans-serif; font-weight: 600;">{{ (tz "Europe/Rome" .StartsAt).Format "2006-01-02 15:04:05 MST" }} ({{ .StartsAt.UTC.Format "2006-01-02 15:04:05" }} UTC)</td>
+                                <td style="font-size: 13px; color: #dc2626; font-family: 'Poppins', Arial, sans-serif; font-weight: 600;">{{ template "ts_en" .StartsAt }}</td>
+                              </tr>
+                              <tr>
+                                <td style="font-size: 11px; color: #6b7280; font-family: 'Poppins', Arial, sans-serif; padding-top: 3px;">{{ template "ts_utc" .StartsAt }}</td>
                               </tr>
                             </table>
                           </td>

--- a/backend/services/alerting/templates/firing_en.html
+++ b/backend/services/alerting/templates/firing_en.html
@@ -166,7 +166,7 @@
                                 <td style="font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.8px; color: #6b7280; font-family: 'Poppins', Arial, sans-serif; padding-bottom: 6px;">FIRING SINCE</td>
                               </tr>
                               <tr>
-                                <td style="font-size: 13px; color: #dc2626; font-family: 'Poppins', Arial, sans-serif; font-weight: 600;">{{ .StartsAt.UTC.Format "2006-01-02 15:04:05" }} UTC</td>
+                                <td style="font-size: 13px; color: #dc2626; font-family: 'Poppins', Arial, sans-serif; font-weight: 600;">{{ (tz "Europe/Rome" .StartsAt).Format "2006-01-02 15:04:05 MST" }} ({{ .StartsAt.UTC.Format "2006-01-02 15:04:05" }} UTC)</td>
                               </tr>
                             </table>
                           </td>

--- a/backend/services/alerting/templates/firing_en.txt
+++ b/backend/services/alerting/templates/firing_en.txt
@@ -22,7 +22,7 @@ DETAILS:  {{ .Annotations.description_en }}
 {{ else if .Annotations.description -}}
 DETAILS:  {{ .Annotations.description }}
 {{ end -}}
-SINCE:    {{ .StartsAt.UTC.Format "2006-01-02 15:04:05" }} UTC
+SINCE:    {{ (tz "Europe/Rome" .StartsAt).Format "2006-01-02 15:04:05 MST" }} ({{ .StartsAt.UTC.Format "2006-01-02 15:04:05" }} UTC)
 
 ───────────────────────────────────────────────────────────────
   SYSTEM

--- a/backend/services/alerting/templates/firing_en.txt
+++ b/backend/services/alerting/templates/firing_en.txt
@@ -7,35 +7,36 @@
   ALERT
 ═══════════════════════════════════════════════════════════════
 
-ALERT:    {{ .Labels.alertname }}
-SEVERITY: {{ .Labels.severity | toUpper }}
+ALERT:        {{ .Labels.alertname }}
+SEVERITY:     {{ .Labels.severity | toUpper }}
 {{ if .Labels.service -}}
-SERVICE:  {{ .Labels.service }}
+SERVICE:      {{ .Labels.service }}
 {{ end -}}
 {{ if .Annotations.summary_en -}}
-SUMMARY:  {{ .Annotations.summary_en }}
+SUMMARY:      {{ .Annotations.summary_en }}
 {{ else if .Annotations.summary -}}
-SUMMARY:  {{ .Annotations.summary }}
+SUMMARY:      {{ .Annotations.summary }}
 {{ end -}}
 {{ if .Annotations.description_en -}}
-DETAILS:  {{ .Annotations.description_en }}
+DETAILS:      {{ .Annotations.description_en }}
 {{ else if .Annotations.description -}}
-DETAILS:  {{ .Annotations.description }}
+DETAILS:      {{ .Annotations.description }}
 {{ end -}}
-SINCE:    {{ (tz "Europe/Rome" .StartsAt).Format "2006-01-02 15:04:05 MST" }} ({{ .StartsAt.UTC.Format "2006-01-02 15:04:05" }} UTC)
+FIRING SINCE: {{ template "ts_en" .StartsAt }}
+              {{ template "ts_utc" .StartsAt }}
 
 ───────────────────────────────────────────────────────────────
   SYSTEM
 ───────────────────────────────────────────────────────────────
 
 {{ if .Labels.organization_name -}}
-{{ if eq .Labels.organization_type "customer" }}CUSTOMER: {{ else if eq .Labels.organization_type "reseller" }}RESELLER: {{ else if eq .Labels.organization_type "distributor" }}DISTRIB.: {{ else }}ORG.:     {{ end }}{{ if .Labels.organization_vat }}{{ .Labels.organization_vat }} - {{ end }}{{ .Labels.organization_name }}
+{{ if eq .Labels.organization_type "customer" }}CUSTOMER:     {{ else if eq .Labels.organization_type "reseller" }}RESELLER:     {{ else if eq .Labels.organization_type "distributor" }}DISTRIBUTOR:  {{ else }}ORGANIZATION: {{ end }}{{ if .Labels.organization_vat }}{{ .Labels.organization_vat }} - {{ end }}{{ .Labels.organization_name }}
 {{ end -}}
 {{ if or .Labels.system_name .Labels.system_key -}}
-SYSTEM:   {{ if .Labels.system_name }}{{ .Labels.system_name }}{{ if .Labels.system_key }} ({{ .Labels.system_key }}){{ end }}{{ else }}{{ .Labels.system_key }}{{ end }}
+SYSTEM:       {{ if .Labels.system_name }}{{ .Labels.system_name }}{{ if .Labels.system_key }} ({{ .Labels.system_key }}){{ end }}{{ else }}{{ .Labels.system_key }}{{ end }}
 {{ end -}}
 {{ if or .Labels.system_fqdn .Labels.system_ipv4 -}}
-{{ if .Labels.system_fqdn }}FQDN:     {{ .Labels.system_fqdn }}{{ else }}IP:       {{ .Labels.system_ipv4 }}{{ end }}
+{{ if .Labels.system_fqdn }}FQDN:         {{ .Labels.system_fqdn }}{{ else }}IP:           {{ .Labels.system_ipv4 }}{{ end }}
 {{ end }}
 {{ if .Labels.system_id -}}
 View system: ${APP_URL}/systems/{{ .Labels.system_id }}

--- a/backend/services/alerting/templates/firing_it.html
+++ b/backend/services/alerting/templates/firing_it.html
@@ -166,7 +166,7 @@
                                 <td style="font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.8px; color: #6b7280; font-family: 'Poppins', Arial, sans-serif; padding-bottom: 6px;">ATTIVO DAL</td>
                               </tr>
                               <tr>
-                                <td style="font-size: 13px; color: #dc2626; font-family: 'Poppins', Arial, sans-serif; font-weight: 600;">{{ .StartsAt.UTC.Format "2006-01-02 15:04:05" }} UTC</td>
+                                <td style="font-size: 13px; color: #dc2626; font-family: 'Poppins', Arial, sans-serif; font-weight: 600;">{{ (tz "Europe/Rome" .StartsAt).Format "2006-01-02 15:04:05 MST" }} ({{ .StartsAt.UTC.Format "2006-01-02 15:04:05" }} UTC)</td>
                               </tr>
                             </table>
                           </td>

--- a/backend/services/alerting/templates/firing_it.html
+++ b/backend/services/alerting/templates/firing_it.html
@@ -148,7 +148,7 @@
                           <td style="padding-bottom: 18px;">
                             <table border="0" cellpadding="0" cellspacing="0" width="100%">
                               <tr>
-                                <td style="font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.8px; color: #6b7280; font-family: 'Poppins', Arial, sans-serif; padding-bottom: 6px;">DESCRIZIONE</td>
+                                <td style="font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.8px; color: #6b7280; font-family: 'Poppins', Arial, sans-serif; padding-bottom: 6px;">DETTAGLI</td>
                               </tr>
                               <tr>
                                 <td style="font-size: 14px; color: #374151; line-height: 1.5; font-family: 'Poppins', Arial, sans-serif;">{{ if .Annotations.description_it }}{{ .Annotations.description_it }}{{ else }}{{ .Annotations.description }}{{ end }}</td>
@@ -166,7 +166,10 @@
                                 <td style="font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.8px; color: #6b7280; font-family: 'Poppins', Arial, sans-serif; padding-bottom: 6px;">ATTIVO DAL</td>
                               </tr>
                               <tr>
-                                <td style="font-size: 13px; color: #dc2626; font-family: 'Poppins', Arial, sans-serif; font-weight: 600;">{{ (tz "Europe/Rome" .StartsAt).Format "2006-01-02 15:04:05 MST" }} ({{ .StartsAt.UTC.Format "2006-01-02 15:04:05" }} UTC)</td>
+                                <td style="font-size: 13px; color: #dc2626; font-family: 'Poppins', Arial, sans-serif; font-weight: 600;">{{ template "ts_it" .StartsAt }}</td>
+                              </tr>
+                              <tr>
+                                <td style="font-size: 11px; color: #6b7280; font-family: 'Poppins', Arial, sans-serif; padding-top: 3px;">{{ template "ts_utc" .StartsAt }}</td>
                               </tr>
                             </table>
                           </td>

--- a/backend/services/alerting/templates/firing_it.txt
+++ b/backend/services/alerting/templates/firing_it.txt
@@ -24,7 +24,7 @@ DETTAGLI:  {{ .Annotations.description_en }}
 {{ else if .Annotations.description -}}
 DETTAGLI:  {{ .Annotations.description }}
 {{ end -}}
-DAL:       {{ .StartsAt.UTC.Format "2006-01-02 15:04:05" }} UTC
+DAL:       {{ (tz "Europe/Rome" .StartsAt).Format "2006-01-02 15:04:05 MST" }} ({{ .StartsAt.UTC.Format "2006-01-02 15:04:05" }} UTC)
 
 ───────────────────────────────────────────────────────────────
   SISTEMA

--- a/backend/services/alerting/templates/firing_it.txt
+++ b/backend/services/alerting/templates/firing_it.txt
@@ -7,37 +7,38 @@
   ALLARME
 ═══════════════════════════════════════════════════════════════
 
-ALLARME:   {{ .Labels.alertname }}
-SEVERITA': {{ .Labels.severity | toUpper }}
+ALLARME:        {{ .Labels.alertname }}
+SEVERITÀ:       {{ .Labels.severity | toUpper }}
 {{ if .Labels.service -}}
-SERVIZIO:  {{ .Labels.service }}
+SERVIZIO:       {{ .Labels.service }}
 {{ end -}}
 {{ if .Annotations.summary_it -}}
-RIEPILOGO: {{ .Annotations.summary_it }}
+RIEPILOGO:      {{ .Annotations.summary_it }}
 {{ else if .Annotations.summary -}}
-RIEPILOGO: {{ .Annotations.summary }}
+RIEPILOGO:      {{ .Annotations.summary }}
 {{ end -}}
 {{ if .Annotations.description_it -}}
-DETTAGLI:  {{ .Annotations.description_it }}
+DETTAGLI:       {{ .Annotations.description_it }}
 {{ else if .Annotations.description_en -}}
-DETTAGLI:  {{ .Annotations.description_en }}
+DETTAGLI:       {{ .Annotations.description_en }}
 {{ else if .Annotations.description -}}
-DETTAGLI:  {{ .Annotations.description }}
+DETTAGLI:       {{ .Annotations.description }}
 {{ end -}}
-DAL:       {{ (tz "Europe/Rome" .StartsAt).Format "2006-01-02 15:04:05 MST" }} ({{ .StartsAt.UTC.Format "2006-01-02 15:04:05" }} UTC)
+ATTIVO DAL:     {{ template "ts_it" .StartsAt }}
+                {{ template "ts_utc" .StartsAt }}
 
 ───────────────────────────────────────────────────────────────
   SISTEMA
 ───────────────────────────────────────────────────────────────
 
 {{ if .Labels.organization_name -}}
-{{ if eq .Labels.organization_type "customer" }}CLIENTE:   {{ else if eq .Labels.organization_type "reseller" }}RIVEND.:   {{ else if eq .Labels.organization_type "distributor" }}DISTRIB.:  {{ else }}ORG.:      {{ end }}{{ if .Labels.organization_vat }}{{ .Labels.organization_vat }} - {{ end }}{{ .Labels.organization_name }}
+{{ if eq .Labels.organization_type "customer" }}CLIENTE:        {{ else if eq .Labels.organization_type "reseller" }}RIVENDITORE:    {{ else if eq .Labels.organization_type "distributor" }}DISTRIBUTORE:   {{ else }}ORGANIZZAZIONE: {{ end }}{{ if .Labels.organization_vat }}{{ .Labels.organization_vat }} - {{ end }}{{ .Labels.organization_name }}
 {{ end -}}
 {{ if or .Labels.system_name .Labels.system_key -}}
-SISTEMA:   {{ if .Labels.system_name }}{{ .Labels.system_name }}{{ if .Labels.system_key }} ({{ .Labels.system_key }}){{ end }}{{ else }}{{ .Labels.system_key }}{{ end }}
+SISTEMA:        {{ if .Labels.system_name }}{{ .Labels.system_name }}{{ if .Labels.system_key }} ({{ .Labels.system_key }}){{ end }}{{ else }}{{ .Labels.system_key }}{{ end }}
 {{ end -}}
 {{ if or .Labels.system_fqdn .Labels.system_ipv4 -}}
-{{ if .Labels.system_fqdn }}FQDN:      {{ .Labels.system_fqdn }}{{ else }}IP:        {{ .Labels.system_ipv4 }}{{ end }}
+{{ if .Labels.system_fqdn }}FQDN:           {{ .Labels.system_fqdn }}{{ else }}IP:             {{ .Labels.system_ipv4 }}{{ end }}
 {{ end }}
 {{ if .Labels.system_id -}}
 Visualizza sistema: ${APP_URL}/systems/{{ .Labels.system_id }}

--- a/backend/services/alerting/templates/resolved_en.html
+++ b/backend/services/alerting/templates/resolved_en.html
@@ -148,7 +148,7 @@
                           <td style="padding-bottom: 18px;">
                             <table border="0" cellpadding="0" cellspacing="0" width="100%">
                               <tr>
-                                <td style="font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.8px; color: #6b7280; font-family: 'Poppins', Arial, sans-serif; padding-bottom: 6px;">DESCRIPTION</td>
+                                <td style="font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.8px; color: #6b7280; font-family: 'Poppins', Arial, sans-serif; padding-bottom: 6px;">DETAILS</td>
                               </tr>
                               <tr>
                                 <td style="font-size: 14px; color: #374151; line-height: 1.5; font-family: 'Poppins', Arial, sans-serif;">{{ if .Annotations.description_en }}{{ .Annotations.description_en }}{{ else }}{{ .Annotations.description }}{{ end }}</td>
@@ -169,7 +169,10 @@
                                       <td style="font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.8px; color: #6b7280; font-family: 'Poppins', Arial, sans-serif; padding-bottom: 6px;">STARTED</td>
                                     </tr>
                                     <tr>
-                                      <td style="font-size: 13px; color: #374151; font-family: 'Poppins', Arial, sans-serif;">{{ (tz "Europe/Rome" .StartsAt).Format "2006-01-02 15:04:05 MST" }} ({{ .StartsAt.UTC.Format "2006-01-02 15:04:05" }} UTC)</td>
+                                      <td style="font-size: 13px; color: #374151; font-family: 'Poppins', Arial, sans-serif;">{{ template "ts_en" .StartsAt }}</td>
+                                    </tr>
+                                    <tr>
+                                      <td style="font-size: 11px; color: #6b7280; font-family: 'Poppins', Arial, sans-serif; padding-top: 3px;">{{ template "ts_utc" .StartsAt }}</td>
                                     </tr>
                                   </table>
                                 </td>
@@ -179,7 +182,10 @@
                                       <td style="font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.8px; color: #6b7280; font-family: 'Poppins', Arial, sans-serif; padding-bottom: 6px;">RESOLVED</td>
                                     </tr>
                                     <tr>
-                                      <td style="font-size: 13px; color: #16a34a; font-family: 'Poppins', Arial, sans-serif; font-weight: 600;">{{ (tz "Europe/Rome" .EndsAt).Format "2006-01-02 15:04:05 MST" }} ({{ .EndsAt.UTC.Format "2006-01-02 15:04:05" }} UTC)</td>
+                                      <td style="font-size: 13px; color: #16a34a; font-family: 'Poppins', Arial, sans-serif; font-weight: 600;">{{ template "ts_en" .EndsAt }}</td>
+                                    </tr>
+                                    <tr>
+                                      <td style="font-size: 11px; color: #6b7280; font-family: 'Poppins', Arial, sans-serif; padding-top: 3px;">{{ template "ts_utc" .EndsAt }}</td>
                                     </tr>
                                   </table>
                                 </td>

--- a/backend/services/alerting/templates/resolved_en.html
+++ b/backend/services/alerting/templates/resolved_en.html
@@ -169,7 +169,7 @@
                                       <td style="font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.8px; color: #6b7280; font-family: 'Poppins', Arial, sans-serif; padding-bottom: 6px;">STARTED</td>
                                     </tr>
                                     <tr>
-                                      <td style="font-size: 13px; color: #374151; font-family: 'Poppins', Arial, sans-serif;">{{ .StartsAt.UTC.Format "2006-01-02 15:04:05" }} UTC</td>
+                                      <td style="font-size: 13px; color: #374151; font-family: 'Poppins', Arial, sans-serif;">{{ (tz "Europe/Rome" .StartsAt).Format "2006-01-02 15:04:05 MST" }} ({{ .StartsAt.UTC.Format "2006-01-02 15:04:05" }} UTC)</td>
                                     </tr>
                                   </table>
                                 </td>
@@ -179,7 +179,7 @@
                                       <td style="font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.8px; color: #6b7280; font-family: 'Poppins', Arial, sans-serif; padding-bottom: 6px;">RESOLVED</td>
                                     </tr>
                                     <tr>
-                                      <td style="font-size: 13px; color: #16a34a; font-family: 'Poppins', Arial, sans-serif; font-weight: 600;">{{ .EndsAt.UTC.Format "2006-01-02 15:04:05" }} UTC</td>
+                                      <td style="font-size: 13px; color: #16a34a; font-family: 'Poppins', Arial, sans-serif; font-weight: 600;">{{ (tz "Europe/Rome" .EndsAt).Format "2006-01-02 15:04:05 MST" }} ({{ .EndsAt.UTC.Format "2006-01-02 15:04:05" }} UTC)</td>
                                     </tr>
                                   </table>
                                 </td>

--- a/backend/services/alerting/templates/resolved_en.txt
+++ b/backend/services/alerting/templates/resolved_en.txt
@@ -22,8 +22,8 @@ DETAILS:  {{ .Annotations.description_en }}
 {{ else if .Annotations.description -}}
 DETAILS:  {{ .Annotations.description }}
 {{ end -}}
-STARTED:  {{ .StartsAt.UTC.Format "2006-01-02 15:04:05" }} UTC
-RESOLVED: {{ .EndsAt.UTC.Format "2006-01-02 15:04:05" }} UTC
+STARTED:  {{ (tz "Europe/Rome" .StartsAt).Format "2006-01-02 15:04:05 MST" }} ({{ .StartsAt.UTC.Format "2006-01-02 15:04:05" }} UTC)
+RESOLVED: {{ (tz "Europe/Rome" .EndsAt).Format "2006-01-02 15:04:05 MST" }} ({{ .EndsAt.UTC.Format "2006-01-02 15:04:05" }} UTC)
 
 ───────────────────────────────────────────────────────────────
   SYSTEM

--- a/backend/services/alerting/templates/resolved_en.txt
+++ b/backend/services/alerting/templates/resolved_en.txt
@@ -7,36 +7,38 @@
   ALERT RESOLVED
 ═══════════════════════════════════════════════════════════════
 
-ALERT:    {{ .Labels.alertname }}
-SEVERITY: {{ .Labels.severity | toUpper }}
+ALERT:        {{ .Labels.alertname }}
+SEVERITY:     {{ .Labels.severity | toUpper }}
 {{ if .Labels.service -}}
-SERVICE:  {{ .Labels.service }}
+SERVICE:      {{ .Labels.service }}
 {{ end -}}
 {{ if .Annotations.summary_en -}}
-SUMMARY:  {{ .Annotations.summary_en }}
+SUMMARY:      {{ .Annotations.summary_en }}
 {{ else if .Annotations.summary -}}
-SUMMARY:  {{ .Annotations.summary }}
+SUMMARY:      {{ .Annotations.summary }}
 {{ end -}}
 {{ if .Annotations.description_en -}}
-DETAILS:  {{ .Annotations.description_en }}
+DETAILS:      {{ .Annotations.description_en }}
 {{ else if .Annotations.description -}}
-DETAILS:  {{ .Annotations.description }}
+DETAILS:      {{ .Annotations.description }}
 {{ end -}}
-STARTED:  {{ (tz "Europe/Rome" .StartsAt).Format "2006-01-02 15:04:05 MST" }} ({{ .StartsAt.UTC.Format "2006-01-02 15:04:05" }} UTC)
-RESOLVED: {{ (tz "Europe/Rome" .EndsAt).Format "2006-01-02 15:04:05 MST" }} ({{ .EndsAt.UTC.Format "2006-01-02 15:04:05" }} UTC)
+STARTED:      {{ template "ts_en" .StartsAt }}
+              {{ template "ts_utc" .StartsAt }}
+RESOLVED:     {{ template "ts_en" .EndsAt }}
+              {{ template "ts_utc" .EndsAt }}
 
 ───────────────────────────────────────────────────────────────
   SYSTEM
 ───────────────────────────────────────────────────────────────
 
 {{ if .Labels.organization_name -}}
-{{ if eq .Labels.organization_type "customer" }}CUSTOMER: {{ else if eq .Labels.organization_type "reseller" }}RESELLER: {{ else if eq .Labels.organization_type "distributor" }}DISTRIB.: {{ else }}ORG.:     {{ end }}{{ if .Labels.organization_vat }}{{ .Labels.organization_vat }} - {{ end }}{{ .Labels.organization_name }}
+{{ if eq .Labels.organization_type "customer" }}CUSTOMER:     {{ else if eq .Labels.organization_type "reseller" }}RESELLER:     {{ else if eq .Labels.organization_type "distributor" }}DISTRIBUTOR:  {{ else }}ORGANIZATION: {{ end }}{{ if .Labels.organization_vat }}{{ .Labels.organization_vat }} - {{ end }}{{ .Labels.organization_name }}
 {{ end -}}
 {{ if or .Labels.system_name .Labels.system_key -}}
-SYSTEM:   {{ if .Labels.system_name }}{{ .Labels.system_name }}{{ if .Labels.system_key }} ({{ .Labels.system_key }}){{ end }}{{ else }}{{ .Labels.system_key }}{{ end }}
+SYSTEM:       {{ if .Labels.system_name }}{{ .Labels.system_name }}{{ if .Labels.system_key }} ({{ .Labels.system_key }}){{ end }}{{ else }}{{ .Labels.system_key }}{{ end }}
 {{ end -}}
 {{ if or .Labels.system_fqdn .Labels.system_ipv4 -}}
-{{ if .Labels.system_fqdn }}FQDN:     {{ .Labels.system_fqdn }}{{ else }}IP:       {{ .Labels.system_ipv4 }}{{ end }}
+{{ if .Labels.system_fqdn }}FQDN:         {{ .Labels.system_fqdn }}{{ else }}IP:           {{ .Labels.system_ipv4 }}{{ end }}
 {{ end }}
 {{ if .Labels.system_id -}}
 View system: ${APP_URL}/systems/{{ .Labels.system_id }}

--- a/backend/services/alerting/templates/resolved_it.html
+++ b/backend/services/alerting/templates/resolved_it.html
@@ -169,7 +169,7 @@
                                       <td style="font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.8px; color: #6b7280; font-family: 'Poppins', Arial, sans-serif; padding-bottom: 6px;">INIZIO</td>
                                     </tr>
                                     <tr>
-                                      <td style="font-size: 13px; color: #374151; font-family: 'Poppins', Arial, sans-serif;">{{ .StartsAt.UTC.Format "2006-01-02 15:04:05" }} UTC</td>
+                                      <td style="font-size: 13px; color: #374151; font-family: 'Poppins', Arial, sans-serif;">{{ (tz "Europe/Rome" .StartsAt).Format "2006-01-02 15:04:05 MST" }} ({{ .StartsAt.UTC.Format "2006-01-02 15:04:05" }} UTC)</td>
                                     </tr>
                                   </table>
                                 </td>
@@ -179,7 +179,7 @@
                                       <td style="font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.8px; color: #6b7280; font-family: 'Poppins', Arial, sans-serif; padding-bottom: 6px;">RISOLTO</td>
                                     </tr>
                                     <tr>
-                                      <td style="font-size: 13px; color: #16a34a; font-family: 'Poppins', Arial, sans-serif; font-weight: 600;">{{ .EndsAt.UTC.Format "2006-01-02 15:04:05" }} UTC</td>
+                                      <td style="font-size: 13px; color: #16a34a; font-family: 'Poppins', Arial, sans-serif; font-weight: 600;">{{ (tz "Europe/Rome" .EndsAt).Format "2006-01-02 15:04:05 MST" }} ({{ .EndsAt.UTC.Format "2006-01-02 15:04:05" }} UTC)</td>
                                     </tr>
                                   </table>
                                 </td>

--- a/backend/services/alerting/templates/resolved_it.html
+++ b/backend/services/alerting/templates/resolved_it.html
@@ -148,7 +148,7 @@
                           <td style="padding-bottom: 18px;">
                             <table border="0" cellpadding="0" cellspacing="0" width="100%">
                               <tr>
-                                <td style="font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.8px; color: #6b7280; font-family: 'Poppins', Arial, sans-serif; padding-bottom: 6px;">DESCRIZIONE</td>
+                                <td style="font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.8px; color: #6b7280; font-family: 'Poppins', Arial, sans-serif; padding-bottom: 6px;">DETTAGLI</td>
                               </tr>
                               <tr>
                                 <td style="font-size: 14px; color: #374151; line-height: 1.5; font-family: 'Poppins', Arial, sans-serif;">{{ if .Annotations.description_it }}{{ .Annotations.description_it }}{{ else }}{{ .Annotations.description }}{{ end }}</td>
@@ -169,7 +169,10 @@
                                       <td style="font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.8px; color: #6b7280; font-family: 'Poppins', Arial, sans-serif; padding-bottom: 6px;">INIZIO</td>
                                     </tr>
                                     <tr>
-                                      <td style="font-size: 13px; color: #374151; font-family: 'Poppins', Arial, sans-serif;">{{ (tz "Europe/Rome" .StartsAt).Format "2006-01-02 15:04:05 MST" }} ({{ .StartsAt.UTC.Format "2006-01-02 15:04:05" }} UTC)</td>
+                                      <td style="font-size: 13px; color: #374151; font-family: 'Poppins', Arial, sans-serif;">{{ template "ts_it" .StartsAt }}</td>
+                                    </tr>
+                                    <tr>
+                                      <td style="font-size: 11px; color: #6b7280; font-family: 'Poppins', Arial, sans-serif; padding-top: 3px;">{{ template "ts_utc" .StartsAt }}</td>
                                     </tr>
                                   </table>
                                 </td>
@@ -179,7 +182,10 @@
                                       <td style="font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.8px; color: #6b7280; font-family: 'Poppins', Arial, sans-serif; padding-bottom: 6px;">RISOLTO</td>
                                     </tr>
                                     <tr>
-                                      <td style="font-size: 13px; color: #16a34a; font-family: 'Poppins', Arial, sans-serif; font-weight: 600;">{{ (tz "Europe/Rome" .EndsAt).Format "2006-01-02 15:04:05 MST" }} ({{ .EndsAt.UTC.Format "2006-01-02 15:04:05" }} UTC)</td>
+                                      <td style="font-size: 13px; color: #16a34a; font-family: 'Poppins', Arial, sans-serif; font-weight: 600;">{{ template "ts_it" .EndsAt }}</td>
+                                    </tr>
+                                    <tr>
+                                      <td style="font-size: 11px; color: #6b7280; font-family: 'Poppins', Arial, sans-serif; padding-top: 3px;">{{ template "ts_utc" .EndsAt }}</td>
                                     </tr>
                                   </table>
                                 </td>

--- a/backend/services/alerting/templates/resolved_it.txt
+++ b/backend/services/alerting/templates/resolved_it.txt
@@ -24,8 +24,8 @@ DETTAGLI:   {{ .Annotations.description_en }}
 {{ else if .Annotations.description -}}
 DETTAGLI:   {{ .Annotations.description }}
 {{ end -}}
-INIZIO:     {{ .StartsAt.UTC.Format "2006-01-02 15:04:05" }} UTC
-RISOLTO:    {{ .EndsAt.UTC.Format "2006-01-02 15:04:05" }} UTC
+INIZIO:     {{ (tz "Europe/Rome" .StartsAt).Format "2006-01-02 15:04:05 MST" }} ({{ .StartsAt.UTC.Format "2006-01-02 15:04:05" }} UTC)
+RISOLTO:    {{ (tz "Europe/Rome" .EndsAt).Format "2006-01-02 15:04:05 MST" }} ({{ .EndsAt.UTC.Format "2006-01-02 15:04:05" }} UTC)
 
 ───────────────────────────────────────────────────────────────
   SISTEMA

--- a/backend/services/alerting/templates/resolved_it.txt
+++ b/backend/services/alerting/templates/resolved_it.txt
@@ -7,38 +7,40 @@
   ALLARME RISOLTO
 ═══════════════════════════════════════════════════════════════
 
-ALLARME:    {{ .Labels.alertname }}
-SEVERITA':  {{ .Labels.severity | toUpper }}
+ALLARME:        {{ .Labels.alertname }}
+SEVERITÀ:       {{ .Labels.severity | toUpper }}
 {{ if .Labels.service -}}
-SERVIZIO:   {{ .Labels.service }}
+SERVIZIO:       {{ .Labels.service }}
 {{ end -}}
 {{ if .Annotations.summary_it -}}
-RIEPILOGO:  {{ .Annotations.summary_it }}
+RIEPILOGO:      {{ .Annotations.summary_it }}
 {{ else if .Annotations.summary -}}
-RIEPILOGO:  {{ .Annotations.summary }}
+RIEPILOGO:      {{ .Annotations.summary }}
 {{ end -}}
 {{ if .Annotations.description_it -}}
-DETTAGLI:   {{ .Annotations.description_it }}
+DETTAGLI:       {{ .Annotations.description_it }}
 {{ else if .Annotations.description_en -}}
-DETTAGLI:   {{ .Annotations.description_en }}
+DETTAGLI:       {{ .Annotations.description_en }}
 {{ else if .Annotations.description -}}
-DETTAGLI:   {{ .Annotations.description }}
+DETTAGLI:       {{ .Annotations.description }}
 {{ end -}}
-INIZIO:     {{ (tz "Europe/Rome" .StartsAt).Format "2006-01-02 15:04:05 MST" }} ({{ .StartsAt.UTC.Format "2006-01-02 15:04:05" }} UTC)
-RISOLTO:    {{ (tz "Europe/Rome" .EndsAt).Format "2006-01-02 15:04:05 MST" }} ({{ .EndsAt.UTC.Format "2006-01-02 15:04:05" }} UTC)
+INIZIO:         {{ template "ts_it" .StartsAt }}
+                {{ template "ts_utc" .StartsAt }}
+RISOLTO:        {{ template "ts_it" .EndsAt }}
+                {{ template "ts_utc" .EndsAt }}
 
 ───────────────────────────────────────────────────────────────
   SISTEMA
 ───────────────────────────────────────────────────────────────
 
 {{ if .Labels.organization_name -}}
-{{ if eq .Labels.organization_type "customer" }}CLIENTE:    {{ else if eq .Labels.organization_type "reseller" }}RIVEND.:    {{ else if eq .Labels.organization_type "distributor" }}DISTRIB.:   {{ else }}ORG.:       {{ end }}{{ if .Labels.organization_vat }}{{ .Labels.organization_vat }} - {{ end }}{{ .Labels.organization_name }}
+{{ if eq .Labels.organization_type "customer" }}CLIENTE:        {{ else if eq .Labels.organization_type "reseller" }}RIVENDITORE:    {{ else if eq .Labels.organization_type "distributor" }}DISTRIBUTORE:   {{ else }}ORGANIZZAZIONE: {{ end }}{{ if .Labels.organization_vat }}{{ .Labels.organization_vat }} - {{ end }}{{ .Labels.organization_name }}
 {{ end -}}
 {{ if or .Labels.system_name .Labels.system_key -}}
-SISTEMA:    {{ if .Labels.system_name }}{{ .Labels.system_name }}{{ if .Labels.system_key }} ({{ .Labels.system_key }}){{ end }}{{ else }}{{ .Labels.system_key }}{{ end }}
+SISTEMA:        {{ if .Labels.system_name }}{{ .Labels.system_name }}{{ if .Labels.system_key }} ({{ .Labels.system_key }}){{ end }}{{ else }}{{ .Labels.system_key }}{{ end }}
 {{ end -}}
 {{ if or .Labels.system_fqdn .Labels.system_ipv4 -}}
-{{ if .Labels.system_fqdn }}FQDN:       {{ .Labels.system_fqdn }}{{ else }}IP:         {{ .Labels.system_ipv4 }}{{ end }}
+{{ if .Labels.system_fqdn }}FQDN:           {{ .Labels.system_fqdn }}{{ else }}IP:             {{ .Labels.system_ipv4 }}{{ end }}
 {{ end }}
 {{ if .Labels.system_id -}}
 Visualizza sistema: ${APP_URL}/systems/{{ .Labels.system_id }}

--- a/backend/services/alerting/templates/telegram_en.tmpl
+++ b/backend/services/alerting/templates/telegram_en.tmpl
@@ -14,7 +14,7 @@ Service: <code>{{ .Labels.service }}</code>
 {{ if or .Annotations.description_en .Annotations.description -}}
 Details: {{ if .Annotations.description_en }}{{ .Annotations.description_en }}{{ else }}{{ .Annotations.description }}{{ end }}
 {{ end -}}
-Firing since: {{ (tz "Europe/Rome" .StartsAt).Format "2006-01-02 15:04:05 MST" }} ({{ .StartsAt.UTC.Format "2006-01-02 15:04:05" }} UTC)
+Firing since: {{ template "ts_en" .StartsAt }}
 {{ if .Labels.organization_name -}}
 {{ if eq .Labels.organization_type "customer" }}Customer{{ else if eq .Labels.organization_type "reseller" }}Reseller{{ else if eq .Labels.organization_type "distributor" }}Distributor{{ else }}Organization{{ end }}: {{ if .Labels.organization_vat }}{{ .Labels.organization_vat }} - {{ end }}{{ .Labels.organization_name }}
 {{ end -}}
@@ -44,7 +44,7 @@ Service: <code>{{ .Labels.service }}</code>
 {{ if or .Annotations.description_en .Annotations.description -}}
 Details: {{ if .Annotations.description_en }}{{ .Annotations.description_en }}{{ else }}{{ .Annotations.description }}{{ end }}
 {{ end -}}
-Started: {{ (tz "Europe/Rome" .StartsAt).Format "2006-01-02 15:04:05 MST" }} ({{ .StartsAt.UTC.Format "2006-01-02 15:04:05" }} UTC) | Resolved: {{ (tz "Europe/Rome" .EndsAt).Format "2006-01-02 15:04:05 MST" }} ({{ .EndsAt.UTC.Format "2006-01-02 15:04:05" }} UTC)
+Started: {{ template "ts_en" .StartsAt }} | Resolved: {{ template "ts_en" .EndsAt }}
 {{ if .Labels.organization_name -}}
 {{ if eq .Labels.organization_type "customer" }}Customer{{ else if eq .Labels.organization_type "reseller" }}Reseller{{ else if eq .Labels.organization_type "distributor" }}Distributor{{ else }}Organization{{ end }}: {{ if .Labels.organization_vat }}{{ .Labels.organization_vat }} - {{ end }}{{ .Labels.organization_name }}
 {{ end -}}

--- a/backend/services/alerting/templates/telegram_en.tmpl
+++ b/backend/services/alerting/templates/telegram_en.tmpl
@@ -14,7 +14,7 @@ Service: <code>{{ .Labels.service }}</code>
 {{ if or .Annotations.description_en .Annotations.description -}}
 Details: {{ if .Annotations.description_en }}{{ .Annotations.description_en }}{{ else }}{{ .Annotations.description }}{{ end }}
 {{ end -}}
-Firing since: {{ .StartsAt.UTC.Format "2006-01-02 15:04:05" }} UTC
+Firing since: {{ (tz "Europe/Rome" .StartsAt).Format "2006-01-02 15:04:05 MST" }} ({{ .StartsAt.UTC.Format "2006-01-02 15:04:05" }} UTC)
 {{ if .Labels.organization_name -}}
 {{ if eq .Labels.organization_type "customer" }}Customer{{ else if eq .Labels.organization_type "reseller" }}Reseller{{ else if eq .Labels.organization_type "distributor" }}Distributor{{ else }}Organization{{ end }}: {{ if .Labels.organization_vat }}{{ .Labels.organization_vat }} - {{ end }}{{ .Labels.organization_name }}
 {{ end -}}
@@ -44,7 +44,7 @@ Service: <code>{{ .Labels.service }}</code>
 {{ if or .Annotations.description_en .Annotations.description -}}
 Details: {{ if .Annotations.description_en }}{{ .Annotations.description_en }}{{ else }}{{ .Annotations.description }}{{ end }}
 {{ end -}}
-Started: {{ .StartsAt.UTC.Format "2006-01-02 15:04:05" }} UTC | Resolved: {{ .EndsAt.UTC.Format "2006-01-02 15:04:05" }} UTC
+Started: {{ (tz "Europe/Rome" .StartsAt).Format "2006-01-02 15:04:05 MST" }} ({{ .StartsAt.UTC.Format "2006-01-02 15:04:05" }} UTC) | Resolved: {{ (tz "Europe/Rome" .EndsAt).Format "2006-01-02 15:04:05 MST" }} ({{ .EndsAt.UTC.Format "2006-01-02 15:04:05" }} UTC)
 {{ if .Labels.organization_name -}}
 {{ if eq .Labels.organization_type "customer" }}Customer{{ else if eq .Labels.organization_type "reseller" }}Reseller{{ else if eq .Labels.organization_type "distributor" }}Distributor{{ else }}Organization{{ end }}: {{ if .Labels.organization_vat }}{{ .Labels.organization_vat }} - {{ end }}{{ .Labels.organization_name }}
 {{ end -}}

--- a/backend/services/alerting/templates/telegram_it.tmpl
+++ b/backend/services/alerting/templates/telegram_it.tmpl
@@ -14,7 +14,7 @@ Servizio: <code>{{ .Labels.service }}</code>
 {{ if or .Annotations.description_it .Annotations.description_en .Annotations.description -}}
 Dettagli: {{ if .Annotations.description_it }}{{ .Annotations.description_it }}{{ else if .Annotations.description_en }}{{ .Annotations.description_en }}{{ else }}{{ .Annotations.description }}{{ end }}
 {{ end -}}
-Attivo da: {{ (tz "Europe/Rome" .StartsAt).Format "2006-01-02 15:04:05 MST" }} ({{ .StartsAt.UTC.Format "2006-01-02 15:04:05" }} UTC)
+Attivo dal: {{ template "ts_it" .StartsAt }}
 {{ if .Labels.organization_name -}}
 {{ if eq .Labels.organization_type "customer" }}Cliente{{ else if eq .Labels.organization_type "reseller" }}Rivenditore{{ else if eq .Labels.organization_type "distributor" }}Distributore{{ else }}Organizzazione{{ end }}: {{ if .Labels.organization_vat }}{{ .Labels.organization_vat }} - {{ end }}{{ .Labels.organization_name }}
 {{ end -}}
@@ -44,7 +44,7 @@ Servizio: <code>{{ .Labels.service }}</code>
 {{ if or .Annotations.description_it .Annotations.description_en .Annotations.description -}}
 Dettagli: {{ if .Annotations.description_it }}{{ .Annotations.description_it }}{{ else if .Annotations.description_en }}{{ .Annotations.description_en }}{{ else }}{{ .Annotations.description }}{{ end }}
 {{ end -}}
-Attivo da: {{ (tz "Europe/Rome" .StartsAt).Format "2006-01-02 15:04:05 MST" }} ({{ .StartsAt.UTC.Format "2006-01-02 15:04:05" }} UTC) | Risolto: {{ (tz "Europe/Rome" .EndsAt).Format "2006-01-02 15:04:05 MST" }} ({{ .EndsAt.UTC.Format "2006-01-02 15:04:05" }} UTC)
+Inizio: {{ template "ts_it" .StartsAt }} | Risolto: {{ template "ts_it" .EndsAt }}
 {{ if .Labels.organization_name -}}
 {{ if eq .Labels.organization_type "customer" }}Cliente{{ else if eq .Labels.organization_type "reseller" }}Rivenditore{{ else if eq .Labels.organization_type "distributor" }}Distributore{{ else }}Organizzazione{{ end }}: {{ if .Labels.organization_vat }}{{ .Labels.organization_vat }} - {{ end }}{{ .Labels.organization_name }}
 {{ end -}}

--- a/backend/services/alerting/templates/telegram_it.tmpl
+++ b/backend/services/alerting/templates/telegram_it.tmpl
@@ -14,7 +14,7 @@ Servizio: <code>{{ .Labels.service }}</code>
 {{ if or .Annotations.description_it .Annotations.description_en .Annotations.description -}}
 Dettagli: {{ if .Annotations.description_it }}{{ .Annotations.description_it }}{{ else if .Annotations.description_en }}{{ .Annotations.description_en }}{{ else }}{{ .Annotations.description }}{{ end }}
 {{ end -}}
-Attivo da: {{ .StartsAt.UTC.Format "2006-01-02 15:04:05" }} UTC
+Attivo da: {{ (tz "Europe/Rome" .StartsAt).Format "2006-01-02 15:04:05 MST" }} ({{ .StartsAt.UTC.Format "2006-01-02 15:04:05" }} UTC)
 {{ if .Labels.organization_name -}}
 {{ if eq .Labels.organization_type "customer" }}Cliente{{ else if eq .Labels.organization_type "reseller" }}Rivenditore{{ else if eq .Labels.organization_type "distributor" }}Distributore{{ else }}Organizzazione{{ end }}: {{ if .Labels.organization_vat }}{{ .Labels.organization_vat }} - {{ end }}{{ .Labels.organization_name }}
 {{ end -}}
@@ -44,7 +44,7 @@ Servizio: <code>{{ .Labels.service }}</code>
 {{ if or .Annotations.description_it .Annotations.description_en .Annotations.description -}}
 Dettagli: {{ if .Annotations.description_it }}{{ .Annotations.description_it }}{{ else if .Annotations.description_en }}{{ .Annotations.description_en }}{{ else }}{{ .Annotations.description }}{{ end }}
 {{ end -}}
-Attivo da: {{ .StartsAt.UTC.Format "2006-01-02 15:04:05" }} UTC | Risolto: {{ .EndsAt.UTC.Format "2006-01-02 15:04:05" }} UTC
+Attivo da: {{ (tz "Europe/Rome" .StartsAt).Format "2006-01-02 15:04:05 MST" }} ({{ .StartsAt.UTC.Format "2006-01-02 15:04:05" }} UTC) | Risolto: {{ (tz "Europe/Rome" .EndsAt).Format "2006-01-02 15:04:05 MST" }} ({{ .EndsAt.UTC.Format "2006-01-02 15:04:05" }} UTC)
 {{ if .Labels.organization_name -}}
 {{ if eq .Labels.organization_type "customer" }}Cliente{{ else if eq .Labels.organization_type "reseller" }}Rivenditore{{ else if eq .Labels.organization_type "distributor" }}Distributore{{ else }}Organizzazione{{ end }}: {{ if .Labels.organization_vat }}{{ .Labels.organization_vat }} - {{ end }}{{ .Labels.organization_name }}
 {{ end -}}

--- a/services/mimir/Containerfile
+++ b/services/mimir/Containerfile
@@ -4,7 +4,7 @@ FROM docker.io/grafana/mimir:3.0.6 AS mimir
 # Final stage: alpine with shell for entrypoint script
 FROM alpine:3.24
 
-RUN apk add --no-cache gettext
+RUN apk add --no-cache gettext tzdata
 
 # Copy mimir binary from official image
 COPY --from=mimir /bin/mimir /bin/mimir

--- a/services/mimir/docker-compose.local.yml
+++ b/services/mimir/docker-compose.local.yml
@@ -15,7 +15,6 @@ services:
     volumes:
       - ./my-local.yaml:/etc/mimir/my.yaml:ro
       - ./runtime_config.yaml:/etc/mimir/runtime_config.yaml:ro
-      - /usr/share/zoneinfo:/usr/share/zoneinfo:ro
       - mimir-data:/data
     ports:
       - "9009:9009"

--- a/services/mimir/docker-compose.local.yml
+++ b/services/mimir/docker-compose.local.yml
@@ -15,6 +15,7 @@ services:
     volumes:
       - ./my-local.yaml:/etc/mimir/my.yaml:ro
       - ./runtime_config.yaml:/etc/mimir/runtime_config.yaml:ro
+      - /usr/share/zoneinfo:/usr/share/zoneinfo:ro
       - mimir-data:/data
     ports:
       - "9009:9009"


### PR DESCRIPTION
Alert emails/Telegram messages showed StartsAt/EndsAt in UTC only,
confusing recipients checking against wall-clock time. Uses
Alertmanager's tz func to add Europe/Rome time (CEST/CET) next to UTC.

Assisted-by: Claude Code:claude-sonnet-5