### PR TITLE
fix(collect): stop false LinkFailed alerts when My is down

### DIFF
--- a/collect/.env.example
+++ b/collect/.env.example
@@ -79,7 +79,10 @@ REDIS_URL=redis://localhost:6379
 # Notification configuration
 #NOTIFICATION_RETRY_ATTEMPTS=3
 
-# Heartbeat monitoring configuration
+# Heartbeat monitoring configuration. The timeout is also how long the monitor
+# must watch heartbeats being recorded before it will mark anything offline, so
+# raising it also lengthens the window after a restart in which no system can be
+# reported down.
 #HEARTBEAT_TIMEOUT_MINUTES=20
 
 # Backup storage (DigitalOcean Spaces — shared S3 account with Mimir)

--- a/collect/README.md
+++ b/collect/README.md
@@ -85,6 +85,7 @@ LOG_LEVEL=info
   - `active` → `inactive` when the heartbeat is stale (older than `HEARTBEAT_TIMEOUT_MINUTES`)
   - `unknown` → `active` as a safety net for the inline flip
 - Configurable timeout via `HEARTBEAT_TIMEOUT_MINUTES` (default: 20 minutes)
+- A system reaches `inactive` only if My was recording heartbeats for the whole window it is judged on. The monitor watches the newest beat among active systems and counts consecutive checks in which recording was visibly happening; until those checks span a full `HEARTBEAT_TIMEOUT_MINUTES`, nothing is marked offline and no `LinkFailed` is raised. Systems already `inactive` keep their alerts throughout. The count resets when collect restarts, since that is a window nobody observed.
 
 **7. LinkFailed Synchronization**
 - **LinkFailed Monitor Cron** runs every 5 minutes

--- a/collect/cron/heartbeat_monitor.go
+++ b/collect/cron/heartbeat_monitor.go
@@ -26,6 +26,10 @@ type HeartbeatMonitor struct {
 	db               *sql.DB
 	timeoutMinutes   int
 	checkIntervalSec int
+	// observedChecks counts consecutive checks in which My was visibly recording
+	// heartbeats; see canJudgeSilence. Only touched from the single
+	// checkAndUpdateStatuses goroutine.
+	observedChecks int
 	// postAlerts resolves LinkFailed alerts when a system recovers. Injectable
 	// for tests; defaults to the real Mimir client.
 	postAlerts postAlertsFunc
@@ -35,6 +39,13 @@ type HeartbeatMonitor struct {
 // (config not loaded, e.g. in tests) so the ticker never gets a non-positive
 // duration.
 const defaultHeartbeatCheckIntervalSec = 300
+
+// fleetSilenceTolerance is how old the newest heartbeat in the whole fleet may
+// be before a check counts as unobserved. Thousands of systems beat every few
+// minutes, so the newest of them is normally seconds old; minutes of silence
+// across the entire fleet means My was not recording, whatever the reason —
+// collect stopped, Postgres or Redis went away, or nothing reached us at all.
+const fleetSilenceTolerance = 3 * time.Minute
 
 // NewHeartbeatMonitor creates a new heartbeat monitor instance
 func NewHeartbeatMonitor() *HeartbeatMonitor {
@@ -141,6 +152,14 @@ func (h *HeartbeatMonitor) checkAndUpdateStatuses(ctx context.Context) {
 	// the heartbeat interval flirts with the timeout, so it never clears.
 	h.resolveRecovered(ctx, recoveredIDs)
 
+	// A LinkFailed asserts that a system has not talked to us for the timeout,
+	// and that is only true if we were listening for the whole window. Marking
+	// systems inactive is what raises it, so hold the transition until we have
+	// watched long enough to make the claim.
+	if !h.canJudgeSilence(ctx) {
+		return
+	}
+
 	// Update systems to 'inactive' if they have old heartbeat and are currently 'active'
 	queryInactive := `
 		UPDATE systems s
@@ -168,6 +187,92 @@ func (h *HeartbeatMonitor) checkAndUpdateStatuses(ctx context.Context) {
 	logger.Debug().
 		Time("cutoff", cutoff).
 		Msg("Heartbeat status check completed")
+}
+
+// canJudgeSilence reports whether the monitor has watched long enough to say
+// that a system has gone quiet.
+//
+// Time in which My was down is time nobody observed: a heartbeat that never
+// arrived because we were not there to take it says nothing about the system
+// that sent it. So the monitor watches the newest heartbeat in the fleet — with
+// thousands of systems beating, it is seconds old whenever recording works —
+// and counts consecutive checks in which recording was visibly happening. Only
+// once those checks span a whole timeout has any system had a fully observed
+// window in which to report, and only then can silence be held against it.
+//
+// The counter lives in memory on purpose: collect restarting is itself a window
+// nobody observed, so losing the count on restart is the correct behaviour.
+func (h *HeartbeatMonitor) canJudgeSilence(ctx context.Context) bool {
+	// Read the newest beat among the systems this transition can actually touch.
+	// Taken over the whole table the reading answers "is anyone beating at all",
+	// which is a different question: once every row belongs to a system that is
+	// already offline, the newest beat is frozen for good and the check would
+	// hold the transition forever.
+	var newest sql.NullTime
+	if err := h.db.QueryRowContext(ctx, `
+		SELECT MAX(h.last_heartbeat)
+		FROM system_heartbeats h
+		INNER JOIN systems s ON s.id = h.system_id
+		WHERE s.status = 'active'
+			AND s.deleted_at IS NULL
+	`).Scan(&newest); err != nil {
+		// Without the reading there is no evidence either way. Carry on: the
+		// update below runs on the same connection and will fail too if the
+		// database is the problem, and a spurious alert beats a missed one.
+		logger.Error().Err(err).Msg("Failed to read the newest heartbeat in the fleet")
+		return true
+	}
+
+	required := h.requiredObservedChecks()
+
+	if !newest.Valid {
+		// No active system has ever beaten, so the transition below has nothing
+		// to act on and there is nothing to withhold judgement about.
+		return true
+	}
+
+	if time.Since(newest.Time) > fleetSilenceTolerance {
+		if h.observedChecks > 0 {
+			logger.Error().
+				Time("newest_heartbeat", newest.Time).
+				Dur("tolerance", fleetSilenceTolerance).
+				Int("checks_required", required).
+				Msg("My is not recording heartbeats: no system will be marked offline until recording has been observed again for a full timeout")
+		}
+		h.observedChecks = 0
+		return false
+	}
+
+	if h.observedChecks < required {
+		h.observedChecks++
+		if h.observedChecks < required {
+			logger.Debug().
+				Int("checks_observed", h.observedChecks).
+				Int("checks_required", required).
+				Msg("Waiting to observe a full timeout of heartbeat recording before judging silence")
+			return false
+		}
+		logger.Info().
+			Int("checks_required", required).
+			Msg("Heartbeat recording observed for a full timeout: systems can be marked offline again")
+	}
+
+	return true
+}
+
+// requiredObservedChecks is how many consecutive checks cover a whole timeout,
+// rounded up so the observed window is never shorter than the one a LinkFailed
+// claims to have watched.
+func (h *HeartbeatMonitor) requiredObservedChecks() int {
+	intervalSec := h.checkIntervalSec
+	if intervalSec <= 0 {
+		intervalSec = defaultHeartbeatCheckIntervalSec
+	}
+	checks := (h.timeoutMinutes*60 + intervalSec - 1) / intervalSec
+	if checks < 1 {
+		checks = 1
+	}
+	return checks
 }
 
 // resolveRecovered posts a resolved LinkFailed alert for each system that just

--- a/collect/cron/heartbeat_monitor_test.go
+++ b/collect/cron/heartbeat_monitor_test.go
@@ -11,6 +11,7 @@ package cron
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -85,6 +86,7 @@ func TestCheckAndUpdateStatuses_ResolvesRecoveredSystem(t *testing.T) {
 		db:               db,
 		timeoutMinutes:   10,
 		checkIntervalSec: 60,
+		observedChecks:   observedWindowMet,
 		postAlerts: func(orgID string, alerts []models.AlertmanagerPostAlert) error {
 			posted[orgID] = append(posted[orgID], alerts...)
 			return nil
@@ -107,6 +109,7 @@ func TestCheckAndUpdateStatuses_ResolvesRecoveredSystem(t *testing.T) {
 			"org_name", "org_vat", "org_type", "reseller_org_id",
 		}).AddRow("sys-uuid-1", "org-1", "SYS-001", "web-01", "ns8", "", "", "Reseller X", "", "reseller", "reseller-1"))
 	// 4. active -> inactive
+	expectFleetObserved(mock)
 	mock.ExpectExec(`SET status = 'inactive'`).
 		WithArgs(sqlmock.AnyArg()).
 		WillReturnResult(sqlmock.NewResult(0, 0))
@@ -137,6 +140,7 @@ func TestCheckAndUpdateStatuses_NoRecovery_NoResolve(t *testing.T) {
 		db:               db,
 		timeoutMinutes:   10,
 		checkIntervalSec: 60,
+		observedChecks:   observedWindowMet,
 		postAlerts: func(string, []models.AlertmanagerPostAlert) error {
 			called = true
 			return nil
@@ -149,6 +153,7 @@ func TestCheckAndUpdateStatuses_NoRecovery_NoResolve(t *testing.T) {
 	mock.ExpectExec(`s\.status = 'unknown'`).
 		WithArgs(sqlmock.AnyArg()).
 		WillReturnResult(sqlmock.NewResult(0, 0))
+	expectFleetObserved(mock)
 	mock.ExpectExec(`SET status = 'inactive'`).
 		WithArgs(sqlmock.AnyArg()).
 		WillReturnResult(sqlmock.NewResult(0, 0))
@@ -157,4 +162,156 @@ func TestCheckAndUpdateStatuses_NoRecovery_NoResolve(t *testing.T) {
 
 	require.NoError(t, mock.ExpectationsWereMet())
 	assert.False(t, called, "postAlerts must not be called when nothing recovered")
+}
+
+// expectFleetObserved queues the one fleet-freshness read a warmed-up monitor
+// makes, so a test can get straight to the transition it is really about.
+func expectFleetObserved(mock sqlmock.Sqlmock) {
+	mock.ExpectQuery(`MAX\(h\.last_heartbeat\).+s\.status = 'active'`).
+		WillReturnRows(sqlmock.NewRows([]string{"max"}).AddRow(time.Now()))
+}
+
+// observedWindowMet is an observedChecks value past any required count, for
+// tests whose subject is not the observation window itself.
+const observedWindowMet = 1 << 20
+
+func TestRequiredObservedChecks(t *testing.T) {
+	tests := []struct {
+		name        string
+		timeoutMin  int
+		intervalSec int
+		want        int
+	}{
+		{"production defaults", 20, 300, 4},
+		{"the PR timeout", 30, 300, 6},
+		{"rounds up rather than short-changing the window", 7, 300, 2},
+		{"interval longer than the timeout still checks once", 1, 300, 1},
+		{"unconfigured interval falls back", 20, 0, 4},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &HeartbeatMonitor{timeoutMinutes: tt.timeoutMin, checkIntervalSec: tt.intervalSec}
+			assert.Equal(t, tt.want, m.requiredObservedChecks())
+		})
+	}
+}
+
+// The requirement in one test: while My is not recording, nothing is marked
+// offline, so no LinkFailed can be raised for a fault on our side.
+func TestCanJudgeSilence_RefusesWhileTheFleetIsUnrecorded(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	monitor := &HeartbeatMonitor{db: db, timeoutMinutes: 20, checkIntervalSec: 300, observedChecks: 4}
+
+	mock.ExpectQuery(`MAX\(h\.last_heartbeat\).+s\.status = 'active'`).
+		WillReturnRows(sqlmock.NewRows([]string{"max"}).AddRow(time.Now().Add(-9 * time.Minute)))
+
+	assert.False(t, monitor.canJudgeSilence(context.Background()))
+	assert.Zero(t, monitor.observedChecks, "an unobserved check restarts the window")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// Recording alone is not enough: the window must be as long as the one a
+// LinkFailed claims to have watched, which is what stops the storm on recovery.
+func TestCanJudgeSilence_WaitsForAFullTimeoutOfRecording(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	monitor := &HeartbeatMonitor{db: db, timeoutMinutes: 20, checkIntervalSec: 300}
+	require.Equal(t, 4, monitor.requiredObservedChecks())
+
+	for i := 0; i < 5; i++ {
+		mock.ExpectQuery(`MAX\(h\.last_heartbeat\).+s\.status = 'active'`).
+			WillReturnRows(sqlmock.NewRows([]string{"max"}).AddRow(time.Now()))
+	}
+
+	var verdicts []bool
+	for i := 0; i < 5; i++ {
+		verdicts = append(verdicts, monitor.canJudgeSilence(context.Background()))
+	}
+
+	assert.Equal(t, []bool{false, false, false, true, true}, verdicts)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// A single unrecorded check restarts the window: a flapping ingest never
+// accumulates the evidence it needs.
+func TestCanJudgeSilence_OneUnrecordedCheckRestartsTheWindow(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	monitor := &HeartbeatMonitor{db: db, timeoutMinutes: 20, checkIntervalSec: 300}
+
+	fresh := func() *sqlmock.Rows {
+		return sqlmock.NewRows([]string{"max"}).AddRow(time.Now())
+	}
+	stale := func() *sqlmock.Rows {
+		return sqlmock.NewRows([]string{"max"}).AddRow(time.Now().Add(-10 * time.Minute))
+	}
+	for _, rows := range []*sqlmock.Rows{fresh(), fresh(), fresh(), stale(), fresh()} {
+		mock.ExpectQuery(`MAX\(h\.last_heartbeat\).+s\.status = 'active'`).WillReturnRows(rows)
+	}
+
+	for i := 0; i < 5; i++ {
+		assert.False(t, monitor.canJudgeSilence(context.Background()), "check %d", i)
+	}
+	assert.Equal(t, 1, monitor.observedChecks, "counting starts over after the gap")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// With no active system that has ever beaten there is nothing to judge and
+// nothing the transition could touch. Withholding here would be a trap: once
+// every remaining beat belongs to a system that is already offline, the reading
+// can never come back and the check would hold the transition for good.
+func TestCanJudgeSilence_NoActiveSystemToJudge(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	monitor := &HeartbeatMonitor{db: db, timeoutMinutes: 20, checkIntervalSec: 300}
+
+	mock.ExpectQuery(`MAX\(h\.last_heartbeat\).+s\.status = 'active'`).
+		WillReturnRows(sqlmock.NewRows([]string{"max"}).AddRow(nil))
+
+	assert.True(t, monitor.canJudgeSilence(context.Background()))
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// The reading must ignore systems that are already offline: their beats are
+// frozen by definition, and letting them set the newest-beat reading is what
+// turns a fleet of dead systems into a permanently closed gate.
+func TestCanJudgeSilence_IgnoresAlreadyOfflineSystems(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	monitor := &HeartbeatMonitor{db: db, timeoutMinutes: 20, checkIntervalSec: 300}
+
+	// An active system beat a moment ago; whatever the offline ones last did is
+	// none of this check's business, so the query filters them out in SQL.
+	mock.ExpectQuery(`MAX\(h\.last_heartbeat\).+INNER JOIN systems.+s\.status = 'active'.+s\.deleted_at IS NULL`).
+		WillReturnRows(sqlmock.NewRows([]string{"max"}).AddRow(time.Now()))
+
+	assert.False(t, monitor.canJudgeSilence(context.Background()), "first observed check of a fresh window")
+	assert.Equal(t, 1, monitor.observedChecks)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// Losing the reading is not evidence of an outage. A spurious alert can be
+// resolved; one that never fires cannot, so the check fails open.
+func TestCanJudgeSilence_FailsOpenOnError(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	monitor := &HeartbeatMonitor{db: db, timeoutMinutes: 20, checkIntervalSec: 300}
+
+	mock.ExpectQuery(`MAX\(h\.last_heartbeat\).+s\.status = 'active'`).WillReturnError(errors.New("connection reset"))
+
+	assert.True(t, monitor.canJudgeSilence(context.Background()))
+	require.NoError(t, mock.ExpectationsWereMet())
 }


### PR DESCRIPTION
> **Parked.** The branch stays as it is; see the comment below for why.

## Summary

A `LinkFailed` says that a system has not talked to us for the timeout. That
holds only if My was recording heartbeats for the whole of that window: if
recording stops, every heartbeat freezes at the same instant and the monitor
reads it as the fleet going offline.

The heartbeat monitor watches the newest beat among active systems — with
thousands of them beating, it is seconds old whenever recording works — and
counts consecutive checks in which recording was visibly happening. Until those
checks span a full `HEARTBEAT_TIMEOUT_MINUTES`, no system is marked inactive, so
no alert can be raised. What stopped the recording does not matter: collect,
Postgres, Redis or nothing reaching us at all produce the same effect and get
the same response.

Two properties matter as much as the suppression:

- **Systems that are genuinely down still alert, however many of them there
  are.** The rule asks whether we were listening, not how many went quiet at
  once.
- **Alerts already firing are never touched.** Only the transition is held, so a
  customer who was already down keeps their alert for the whole outage, with no
  spurious "resolved".

The window also covers restarts: time in which collect was not running is time
nobody observed, so the count starts over and detection resumes one timeout
later. Steady-state detection latency is unchanged; the cost is a 20 minute
window after each restart in which nothing can be reported down.

This is a defence against an outage of ours that the recorded history does not
contain — insurance, not a repair. See the comment for what production actually
shows.

## How to test

Stop recording heartbeats — stop the worker, or take Redis away — while the
fleet keeps beating, and confirm that nothing is marked offline and that
`My is not recording heartbeats` appears once. Then stop a handful of systems
while the rest keep beating, and confirm they are marked inactive and alert as
usual.

Exercised locally against collect, Postgres, Redis and Mimir with a 200 system
fleet, including real registered systems sending heartbeats over HTTP: a
simulated recording gap raised nothing, a 24 system outage alongside 176 healthy
ones alerted in full, a staggered recovery produced no spurious transitions, and
an emptied fleet left the check open.
