### PR TITLE
chore: raise notification repeat_interval

### DIFF
--- a/backend/services/alerting/template.go
+++ b/backend/services/alerting/template.go
@@ -116,7 +116,7 @@ route:
   group_by: ['organization_id', 'alertname', 'system_key']
   group_wait: 30s
   group_interval: 5m
-  repeat_interval: 12h
+  repeat_interval: 8760h
   routes:
 {{- if .HistoryWebhookURL }}
     - receiver: 'builtin-history'


### PR DESCRIPTION
Users do not want to be notified about the same alert after 12 hours.
With the new configuration, notifications are almost fire and forget.

Requested by M.Gori
